### PR TITLE
Make urnik more mobile friendly

### DIFF
--- a/urnik/static/stil.css
+++ b/urnik/static/stil.css
@@ -1,14 +1,39 @@
-.srecanje a {
-    color: #333;
+/* general */
+.padded {
+    padding: 5px;
 }
-.srecanje a:hover, .urejanje a {
+.vertical-space {
+    height: 2000px;  /* allows zoom out on mobile */
+}
+/* navigation and such */
+nav {
+    background-color: #555;
+}
+#urnik-logo {
+    white-space: nowrap;
+}
+@media only screen and (min-width: 600px) {
+    nav a.button-collapse {
+        display:none;
+    }
+}
+.dropdown-content li > a {
     color: #039be5;
 }
-body {
-    /*background: #ddd;*/
+.dropdown-content li.disabled, .dropdown-content li.disabled > a {
+    color: #5e5e5e;
+    cursor: default;
 }
-.container, .navbar {
+/* urnik */
+.urnik-wrapper {
+    position: absolute;
     min-width: 1024px;
+    min-height: 600px;
+    max-width: 1200px;
+    max-height: 1000px;
+    top: 64px;
+    bottom: 0px;
+    width: 100%;
 }
 #urnik.cel {
     position: absolute;
@@ -17,14 +42,12 @@ body {
     width: 95%;
     height: 95%;
     background: white;
-    min-width: 1024px;
-    min-height: 600px;
 }
 #urnik {
     position: absolute;
     left: 0%;
     top: 0%;
-    width: 80%;
+    width: 95%;
     height: 100%;
     background: white;
 }
@@ -86,6 +109,12 @@ body {
     border: solid 1pt white;
     position: absolute;
     padding: 2pt;
+}
+.srecanje a {
+    color: #333;
+}
+.srecanje a:hover, .urejanje a {
+    color: #039be5;
 }
 #informacije .srecanje {
     position: relative;
@@ -271,9 +300,23 @@ a.skrita {
 .alternativa.prosta button, .alternativa.prosta {
     background: orange;
 }
-nav {
-    background-color: #555;
+/* front page */
+.oznaci-vec {
+    position: relative;
+    float: right;
+    font-weight: normal;
 }
+.oznaci-vec > a, .oznaci-vec > button {
+    position: absolute;
+    right: 0px;
+    top: 6px;
+    white-space: nowrap;
+}
+.oznaci-vec > a > i.material-icons, .oznaci-vec > button > i.material-icons {
+    margin-right: 5px;
+}
+
+/* print */
 @media print {
     a {
         color: black;

--- a/urnik/static/stil.css
+++ b/urnik/static/stil.css
@@ -29,36 +29,39 @@ nav {
     position: absolute;
     min-width: 1024px;
     min-height: 600px;
-    max-width: 1200px;
-    max-height: 1000px;
     top: 64px;
     bottom: 0px;
     width: 100%;
 }
-#urnik.cel {
+#urnik {
     position: absolute;
     left: 2.5%;
     top: 2.5%;
-    width: 95%;
+    width: 78%;
     height: 95%;
     background: white;
 }
-#urnik {
-    position: absolute;
-    left: 0%;
-    top: 0%;
+#urnik.cel {
     width: 95%;
-    height: 100%;
-    background: white;
 }
 #informacije {
     position: absolute;
-    left: 82%;
+    left: 81.4%;
     top: 0%;
     width: 18%;
     height: 100%;
-    background: #fff;  
-    overflow-y: scroll;
+    background: #fff;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+#informacije .collapsible-header {
+    white-space: nowrap;
+}
+#informacije .collapsible-body {
+    padding: 5px 20px;
+}
+#informacije .collapsible-body .collection-item {
+    padding: 5px 0px;
 }
 #dnevi {
     position: absolute;

--- a/urnik/templates/_srecanje.html
+++ b/urnik/templates/_srecanje.html
@@ -1,107 +1,107 @@
 {% load tags %}
 <div class="srecanje" style="{{ srecanje.style }}; {% pobarvajvec srecanje.barve %}">
-    <div class="predmet">
-        {% if srecanje.predmet %}
-        <a href="{% url 'urnik_predmeta' srecanje.predmet.id %}">
-            {% if nacin == 'ogled' %}{{ srecanje.po_potrebi_okrajsano_ime_predmeta }}{% else %}{{ srecanje.predmet.kratica }}{% endif %}
-        </a>
-        {% endif %}
-        <span class="tip">
-             {{ srecanje.tip }}{{ srecanje.oznaka }}{{ srecanje.barva }}
-        </span>
-    </div>
+  <div class="predmet">
+    {% if srecanje.predmet %}
+      <a href="{% url 'urnik_predmeta' srecanje.predmet.id %}">
+        {% if nacin == 'ogled' %}{{ srecanje.po_potrebi_okrajsano_ime_predmeta }}{% else %}{{ srecanje.predmet.kratica }}{% endif %}
+      </a>
+    {% endif %}
+    <span class="tip">
+     {{ srecanje.tip }}{{ srecanje.oznaka }}{{ srecanje.barva }}
+    </span>
+  </div>
 
-    {% if srecanje.trajanje > 1 %}
+  {% if srecanje.trajanje > 1 %}
     <div class="letniki">
-        {% for letnik in srecanje.predmet.letniki.all %}
+      {% for letnik in srecanje.predmet.letniki.all %}
         <a href="{% url 'urnik_letnika' letnik.id %}">{{ letnik.kratica }}</a>{% if not forloop.last %}, {% endif %}
-        {% endfor %}
+      {% endfor %}
     </div>
-    {% endif %}
+  {% endif %}
 
-    {% if srecanje.sirina >= 0.5 or nacin == 'urejanje' or nacin == 'odlozisce' %}
+  {% if srecanje.sirina >= 0.5 or nacin == 'urejanje' or nacin == 'odlozisce' %}
     <div class="ucitelj">
-        {% for ucitelj in srecanje.ucitelji.all %}
+      {% for ucitelj in srecanje.ucitelji.all %}
         <a href="{% url 'urnik_osebe' ucitelj.id %}">{{ ucitelj.priimek }}</a>{% if not forloop.last %}, {% endif %}
-        {% endfor %}
+      {% endfor %}
     </div>
-    {% endif %}
+  {% endif %}
 
-    {% if srecanje.ucilnica %}
+  {% if srecanje.ucilnica %}
     <div class="ucilnica">
-        <a href="{% url 'urnik_ucilnice' srecanje.ucilnica.id %}">{{ srecanje.ucilnica.oznaka }}</a>
+      <a href="{% url 'urnik_ucilnice' srecanje.ucilnica.id %}">{{ srecanje.ucilnica.oznaka }}</a>
     </div>
-    {% endif %}
+  {% endif %}
 
-    {% if nacin == 'urejanje' or nacin == 'odlozisce' %}
-        <div class="urejanje">
-            {% if srecanje.lahko_skrajsam %}
-            <form method="post" action="{% url 'nastavi_trajanje_srecanja' srecanje.id %}">
-                {% csrf_token %}
-                <input type="hidden" name="trajanje" value="{{ srecanje.trajanje|add:-1 }}">
-                <button>
-                    <i class="tiny material-icons">file_upload</i> skrajšaj
-                </button>
-            </form>
-            {% endif %}
-            {% if srecanje.lahko_podaljsam %}
-            <form method="post" action="{% url 'nastavi_trajanje_srecanja' srecanje.id %}">
-                {% csrf_token %}
-                <input type="hidden" name="trajanje" value="{{ srecanje.trajanje|add:1 }}">
-                <button>
-                    <i class="tiny material-icons">file_download</i> podaljšaj
-                </button>
-            </form>
-            {% endif %}
-            <a href="{% url 'admin:urnik_srecanje_change' srecanje.id %}?next={{ next }}">
-                <i class="tiny material-icons">edit</i> uredi
+  {% if nacin == 'urejanje' or nacin == 'odlozisce' %}
+    <div class="urejanje">
+      {% if srecanje.lahko_skrajsam %}
+        <form method="post" action="{% url 'nastavi_trajanje_srecanja' srecanje.id %}">
+          {% csrf_token %}
+          <input type="hidden" name="trajanje" value="{{ srecanje.trajanje|add:-1 }}">
+          <button>
+            <i class="tiny material-icons">file_upload</i> skrajšaj
+          </button>
+        </form>
+      {% endif %}
+      {% if srecanje.lahko_podaljsam %}
+        <form method="post" action="{% url 'nastavi_trajanje_srecanja' srecanje.id %}">
+          {% csrf_token %}
+          <input type="hidden" name="trajanje" value="{{ srecanje.trajanje|add:1 }}">
+          <button>
+            <i class="tiny material-icons">file_download</i> podaljšaj
+          </button>
+        </form>
+      {% endif %}
+      <a href="{% url 'admin:urnik_srecanje_change' srecanje.id %}?next={{ next }}">
+        <i class="tiny material-icons">edit</i> uredi
+      </a>
+      <form method="post" action="{% url 'podvoji_srecanje' srecanje.id %}">
+        {% csrf_token %}
+        <button>
+          <i class="tiny material-icons">content_copy</i> podvoji
+        </button>
+      </form>
+      <a href="{% url 'admin:urnik_srecanje_delete' srecanje.id %}?next={{ next }}">
+        <i class="tiny material-icons">delete</i> pobriši
+      </a>
+      {% if srecanje.lahko_odlozim %}
+        <form method="post" action="{% url 'odlozi_srecanje' srecanje.id %}">
+          {% csrf_token %}
+          <button>
+            <i class="tiny material-icons">move_to_inbox</i> odloži
+          </button>
+        </form>
+      {% endif %}
+      <div class="premakni_srecanje">
+        <a href="">
+          <i class="tiny material-icons">open_with</i> premakni
+        </a>
+        <div class="mozne_ucilnice">
+          <a href="{% url 'premakni_srecanje' srecanje.id %}?tip=velika">
+            <i class="tiny material-icons">group</i>
+            velika (&gt;60)
+          </a>
+          <a href="{% url 'premakni_srecanje' srecanje.id %}?tip=obicajna">
+            <i class="tiny material-icons">person</i>
+            običajna (30-50)
+          </a>
+          <a href="{% url 'premakni_srecanje' srecanje.id %}?tip=majhna">
+            <i class="tiny material-icons">person_outline</i>
+            majhna (&lt;30)
+          </a>
+          <a href="{% url 'premakni_srecanje' srecanje.id %}?tip=racunalniska">
+            <i class="tiny material-icons">computer</i>
+            računalniška
+          </a>
+          {% if 'fizika' in user.groups.all|join:"," %}
+            <a href="{% url 'premakni_srecanje' srecanje.id %}?tip=praktikum">
+              <i class="tiny material-icons">build</i>
+              praktikum
             </a>
-            <form method="post" action="{% url 'podvoji_srecanje' srecanje.id %}">
-                {% csrf_token %}
-                <button>
-                    <i class="tiny material-icons">content_copy</i> podvoji
-                </button>
-            </form>
-            <a href="{% url 'admin:urnik_srecanje_delete' srecanje.id %}?next={{ next }}">
-                <i class="tiny material-icons">delete</i> pobriši
-            </a>
-            {% if srecanje.lahko_odlozim %}
-            <form method="post" action="{% url 'odlozi_srecanje' srecanje.id %}">
-                {% csrf_token %}
-                <button>
-                    <i class="tiny material-icons">move_to_inbox</i> odloži
-                </button>
-            </form>
-            {% endif %}
-            <div class="premakni_srecanje">
-                <a href="">
-                    <i class="tiny material-icons">open_with</i> premakni
-                </a>
-                <div class="mozne_ucilnice">
-                    <a href="{% url 'premakni_srecanje' srecanje.id %}?tip=velika">
-                        <i class="tiny material-icons">group</i>
-                        velika (&gt;60)
-                    </a>
-                    <a href="{% url 'premakni_srecanje' srecanje.id %}?tip=obicajna">
-                        <i class="tiny material-icons">person</i>
-                        običajna (30-50)
-                    </a>
-                    <a href="{% url 'premakni_srecanje' srecanje.id %}?tip=majhna">
-                        <i class="tiny material-icons">person_outline</i>
-                        majhna (&lt;30)
-                    </a>
-                    <a href="{% url 'premakni_srecanje' srecanje.id %}?tip=racunalniska">
-                        <i class="tiny material-icons">computer</i>
-                        računalniška
-                    </a>
-                    {% if 'fizika' in user.groups.all|join:"," %}
-                    <a href="{% url 'premakni_srecanje' srecanje.id %}?tip=praktikum">
-                        <i class="tiny material-icons">build</i>
-                        praktikum
-                    </a>
-                    {% endif %}
-                </div>
-            </div>
+          {% endif %}
         </div>
-    {% endif %}
+      </div>
+    </div>
+  {% endif %}
 </div>

--- a/urnik/templates/navigation.html
+++ b/urnik/templates/navigation.html
@@ -1,0 +1,2 @@
+<li id="domov"><a href="{% url 'zacetna_stran' %}"><i class="material-icons left">home</i>Urnik FMF</a></li>
+<li id="rezervacije"><a href="{% url 'rezervacije' %}"><i class="material-icons left">border_color</i>Rezervacije</a></li>

--- a/urnik/templates/osnova.html
+++ b/urnik/templates/osnova.html
@@ -2,27 +2,27 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8">
-    <link href="//fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>Urnik FMF{% if naslov %} –  {{ naslov }}{% endif %} – zimski semester 2017/18</title>
-    <link rel="stylesheet" href="{% static 'stil.css' %}">
+  <meta charset="utf-8">
+  <link href="//fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Urnik FMF{% if naslov %} –  {{ naslov }}{% endif %} – zimski semester 2017/18</title>
+  <link rel="stylesheet" href="{% static 'stil.css' %}">
 </head>
-
 <body>
-    <div class="navbar-fixed">
-<ul id="user-dropdown" class="dropdown-content">
-  <li><a href="{% url 'admin:index' %}"><i class="material-icons">settings</i>administrativni</a></li>
-  <li><a href="{% url 'preklopi_urejanje' %}">
-    {% if request.session.urejanje %}
-      <i class="material-icons">visibility</i>izklopi urejanje
-    {% else %}
-      <i class="material-icons">edit</i>vklopi urejanje
-    {% endif %}
-  </a></li>
-  <li><a href="{% url 'logout' %}"><i class="material-icons">exit_to_app</i>odjavi me</a></li>
-</ul>
+
+<div class="navbar-fixed">
+  <ul id="user-dropdown" class="dropdown-content">
+    <li><a href="{% url 'admin:index' %}"><i class="material-icons">settings</i>administrativni</a></li>
+    <li><a href="{% url 'preklopi_urejanje' %}">
+      {% if request.session.urejanje %}
+        <i class="material-icons">visibility</i>izklopi urejanje
+      {% else %}
+        <i class="material-icons">edit</i>vklopi urejanje
+      {% endif %}
+    </a></li>
+    <li><a href="{% url 'logout' %}"><i class="material-icons">exit_to_app</i>odjavi me</a></li>
+  </ul>
   <nav>
     <div class="nav-wrapper">
       <span class="brand-logo center">
@@ -34,28 +34,29 @@
         <li id="rezervacije"><a href="{% url 'rezervacije' %}"><i class="material-icons left">border_color</i>Rezervacije</a></li>
       </ul>
       {% if user.is_authenticated %}
-      <ul class="right">
-        <li>
-          <a class="dropdown-button" href="#!" data-activates="user-dropdown">
-            {{ user.get_full_name }}
-            <i class="material-icons right">{% if request.session.urejanje %}edit{% else %}visibility{% endif %}</i>
-          </a>
-        </li>
+        <ul class="right">
+          <li>
+            <a class="dropdown-button" href="#!" data-activates="user-dropdown">
+              {{ user.get_full_name }}
+              <i class="material-icons right">{% if request.session.urejanje %}edit{% else %}visibility{% endif %}</i>
+            </a>
+          </li>
+        </ul>
       {% endif %}
     </div>
   </nav>
+</div>
 
-    </div>
-    <div class="container" style="position: absolute; width: 100%; bottom: 0; top: 64px">
-        {% block content %}{% endblock content %}
-    </div>
+<div class="container" style="position: absolute; width: 100%; bottom: 0; top: 64px">
+  {% block content %}{% endblock content %}
+</div>
 
-    <script type="text/javascript" src="//code.jquery.com/jquery-2.1.1.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
-    <script type="text/javascript">
-        $(document).ready(function() {
-            $(".dropdown-button").dropdown();
-        });
-    </script>
+<script type="text/javascript" src="//code.jquery.com/jquery-2.1.1.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
+<script type="text/javascript">
+    $(document).ready(function () {
+        $(".dropdown-button").dropdown();
+    });
+</script>
 </body>
 </html>

--- a/urnik/templates/osnova.html
+++ b/urnik/templates/osnova.html
@@ -9,54 +9,68 @@
   <title>Urnik FMF{% if naslov %} –  {{ naslov }}{% endif %} – zimski semester 2017/18</title>
   <link rel="stylesheet" href="{% static 'stil.css' %}">
 </head>
-<body>
 
+<body>
 <div class="navbar-fixed">
-  <ul id="user-dropdown" class="dropdown-content">
-    <li><a href="{% url 'admin:index' %}"><i class="material-icons">settings</i>administrativni</a></li>
-    <li><a href="{% url 'preklopi_urejanje' %}">
-      {% if request.session.urejanje %}
-        <i class="material-icons">visibility</i>izklopi urejanje
-      {% else %}
-        <i class="material-icons">edit</i>vklopi urejanje
-      {% endif %}
-    </a></li>
-    <li><a href="{% url 'logout' %}"><i class="material-icons">exit_to_app</i>odjavi me</a></li>
-  </ul>
   <nav>
     <div class="nav-wrapper">
-      <span class="brand-logo center">
+      <a href="#!" class="brand-logo center" id="urnik-logo"> <!-- top centred logo -->
         <i class="large material-icons">schedule</i>
         {{ naslov|default:'Urnik' }}
-      </span>
-      <ul>
-        <li id="domov"><a href="{% url 'zacetna_stran' %}"><i class="material-icons left">home</i>Urnik FMF</a></li>
-        <li id="rezervacije"><a href="{% url 'rezervacije' %}"><i class="material-icons left">border_color</i>Rezervacije</a></li>
-      </ul>
+      </a>
+      <a href="#" data-activates="mobile-sidebar" class="button-collapse"><i class="material-icons">menu</i></a>
+      <ul class="left hide-on-small-and-down"> <!-- top menu -->
+        {% include "navigation.html" %}
+      </ul> <!-- top menu -->
       {% if user.is_authenticated %}
         <ul class="right">
           <li>
-            <a class="dropdown-button" href="#!" data-activates="user-dropdown">
-              {{ user.get_full_name }}
+            <a class="dropdown-button" href="#!" data-activates="user-dropdown" style="display: inline-block">
+              <i class="material-icons right" style="margin-left: 5px;">arrow_drop_down</i>
+              <span class="hide-on-small-and-down">{{ user.get_full_name|default:user.get_username }}</span>
               <i class="material-icons right">{% if request.session.urejanje %}edit{% else %}visibility{% endif %}</i>
             </a>
           </li>
         </ul>
       {% endif %}
-    </div>
+    </div> <!-- nav wrapper -->
+    <ul id="user-dropdown" class="dropdown-content">
+      <li class="disabled hide-on-med-and-up">
+        <a href="#!"><i class="material-icons">person</i>{{ user.get_full_name|default:user.get_username }}</a>
+      </li>
+      <li class="divider hide-on-med-and-up"></li>
+      <li><a href="{% url 'admin:index' %}"><i class="material-icons">settings</i>administracija</a></li>
+      <li><a href="{% url 'preklopi_urejanje' %}">
+        {% if request.session.urejanje %}
+          <i class="material-icons">visibility</i>izklopi urejanje
+        {% else %}
+          <i class="material-icons">edit</i>vklopi urejanje
+        {% endif %}
+      </a></li>
+      <li><a href="{% url 'logout' %}"><i class="material-icons">exit_to_app</i>odjavi me</a></li>
+    </ul>
   </nav>
-</div>
+</div> <!-- navbar fixed -->
+<ul class="side-nav" id="mobile-sidebar"> <!-- side navigation for mobile -->
+  {% include "navigation.html" %}
+</ul> <!-- side nav -->
 
-<div class="container" style="position: absolute; width: 100%; bottom: 0; top: 64px">
-  {% block content %}{% endblock content %}
-</div>
+{% block content %}{% endblock content %}
 
 <script type="text/javascript" src="//code.jquery.com/jquery-2.1.1.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
 <script type="text/javascript">
     $(document).ready(function () {
-        $(".dropdown-button").dropdown();
+        $(".dropdown-button").dropdown({
+            constrainWidth: false,
+            belowOrigin: true,
+            inDuration: 300,
+            outDuration: 100,
+            alignment: "right"
+        });
+        $(".button-collapse").sideNav();
     });
 </script>
+
 </body>
 </html>

--- a/urnik/templates/rezervacije.html
+++ b/urnik/templates/rezervacije.html
@@ -3,53 +3,53 @@
 <div class="container">
 
 <p class="flow-text">
-    Stran z rezervacijami je še v delu. V kratkem bo omogočen tudi obrazec za rezervacijo.
+  Stran z rezervacijami je še v delu. V kratkem bo omogočen tudi obrazec za rezervacijo.
 </p>
 <p class="flow-text">
-    Če morate rezervacijo narediti takoj, se kot doslej obrnite na referat.
-    <strong>Če ni nujno</strong>, pa vljudno prosimo, da kak teden počakate in
-    prispevate k manjši obremenjenosti referatov.
+  Če morate rezervacijo narediti takoj, se kot doslej obrnite na referat.
+  <strong>Če ni nujno</strong>, pa vljudno prosimo, da kak teden počakate in
+  prispevate k manjši obremenjenosti referatov.
 </p>
 
 {% regroup rezervacije by teden as rezervacije_po_tednih %}
 {% for teden in rezervacije_po_tednih %}
-<ul class="collapsible" data-collapsible="expandable">
-<li>
-    <div class="collapsible-header {% if forloop.counter <= 2 %}active{% endif %}">
+  <ul class="collapsible" data-collapsible="expandable">
+    <li>
+      <div class="collapsible-header {% if forloop.counter <= 2 %}active{% endif %}">
         <h5>
-            {{ teden.grouper.0|date:"j. F" }} – {{ teden.grouper.1|date:"j. F Y" }}
+          {{ teden.grouper.0|date:"j. F" }} – {{ teden.grouper.1|date:"j. F Y" }}
         </h5>
-    </div>
-    <div class="collapsible-body">
+      </div>
+      <div class="collapsible-body">
         <ul class="collection with-header">
-        {% for rezervacija in teden.list %}
-        {% ifchanged %}
-        <li class="collection-header">
-            <strong>{{ rezervacija.dan|date:"l, j. F" }}</strong>
-        </li>
-        {% endifchanged %}
-        <li class="collection-item">
-            {{ rezervacija.ucilnica }},
-            {{ rezervacija.od }}–{{ rezervacija.do }},
-            <small>
-                {{ rezervacija.osebe.all|join:", "}},
+          {% for rezervacija in teden.list %}
+            {% ifchanged %}
+              <li class="collection-header">
+                <strong>{{ rezervacija.dan|date:"l, j. F" }}</strong>
+              </li>
+            {% endifchanged %}
+            <li class="collection-item">
+              {{ rezervacija.ucilnica }},
+              {{ rezervacija.od }}–{{ rezervacija.do }},
+              <small>
+                {{ rezervacija.osebe.all|join:", " }},
                 {{ rezervacija.opomba }}
-            </small>
-            {% if user.is_staff %}
-            {% for konflikt in rezervacija.konflikti %}
-            <span class="new badge red" data-badge-caption="">
-                {{ konflikt.predmet }},
-                {{ konflikt.od }}–{{ konflikt.do }},
-                {{ konflikt.ucitelji.all|join:", "}}
-            </span>
-            {% endfor %}
-            {% endif %}
-        </li>
-        {% endfor %}
+              </small>
+              {% if user.is_staff %}
+                {% for konflikt in rezervacija.konflikti %}
+                  <span class="new badge red" data-badge-caption="">
+            {{ konflikt.predmet }},
+            {{ konflikt.od }}–{{ konflikt.do }},
+            {{ konflikt.ucitelji.all|join:", " }}
+        </span>
+                {% endfor %}
+              {% endif %}
+            </li>
+          {% endfor %}
         </ul>
-    </div>
-</li>
-</ul>
+      </div>
+    </li>
+  </ul>
 {% endfor %}
 
 </div>

--- a/urnik/templates/urnik.html
+++ b/urnik/templates/urnik.html
@@ -2,6 +2,8 @@
 {% load tags %}
 {% block content %}
 
+<div class="urnik-wrapper">
+
 {% if nacin == 'ogled' %}
   <div id="urnik" class="{% if not barve %}cel{% endif %}">
     {% dnevi %}
@@ -110,7 +112,9 @@
       {% endif %}
     </ul>
   </div>
-
 {% endif %}
+
+</div>
+<div class="vertical-space hide-on-med-and-up"></div>
 
 {% endblock content %}

--- a/urnik/templates/urnik.html
+++ b/urnik/templates/urnik.html
@@ -69,10 +69,10 @@
             <form method="post" action="{% url 'odlozi_srecanje' premaknjeno_srecanje.id %}">
               {% csrf_token %}
               <input type="hidden" name="next" value="{{ next }}">
-              <a class="btn" style="width: 49%" href="{{ next }}">
+              <a class="btn" style="width: 48%" href="{{ next }}">
                 <i class="small material-icons">cancel</i>
               </a>
-              <button class="btn" style="width: 49%">
+              <button class="btn" style="width: 48%">
                 <i class="material-icons">move_to_inbox</i>
               </button>
             </form>

--- a/urnik/templates/urnik.html
+++ b/urnik/templates/urnik.html
@@ -3,107 +3,113 @@
 {% block content %}
 
 {% if nacin == 'ogled' %}
-<div id="urnik" class="{% if not barve %}cel{% endif %}">
+  <div id="urnik" class="{% if not barve %}cel{% endif %}">
     {% dnevi %}
     {% ure %}
     <div id="srecanja">
-        {% for srecanje in srecanja %}
+      {% for srecanje in srecanja %}
         {% include '_srecanje.html' with nacin='ogled' %}
-        {% endfor %}
+      {% endfor %}
     </div>
-</div>
-{% if barve %}
-<div id='informacije'>
-    <ul class="collapsible" data-collapsible="expandable">
+  </div>
+  {% if barve %}
+    <div id='informacije'>
+      <ul class="collapsible" data-collapsible="expandable">
         <li>
-            <div class="collapsible-header active">
-                <i class="material-icons">line_style</i>Legenda
-            </div>
-            <div class="collapsible-body">
-                {% for barva in barve %}
-                <div class="legenda srecanje ustrezna" style="{% pobarvaj forloop.counter0 %}">{{ barva }}</div>
-                {% endfor %}
-            </div>
+          <div class="collapsible-header active">
+            <i class="material-icons">line_style</i>Legenda
+          </div>
+          <div class="collapsible-body">
+            {% for barva in barve %}
+              <div class="legenda srecanje ustrezna" style="{% pobarvaj forloop.counter0 %}">{{ barva }}</div>
+            {% endfor %}
+          </div>
         </li>
-    </ul>
-</div>
-{% endif %}
+      </ul>
+    </div>
+  {% endif %}
 
 {% elif nacin == 'urejanje' or nacin == 'premikanje' %}
-<div id="urnik">
+  <div id="urnik">
     {% dnevi %}
     {% ure %}
     <div id="srecanja">
-        {% for srecanje in srecanja %}
+      {% for srecanje in srecanja %}
         {% include '_srecanje.html' with nacin='urejanje' %}
-        {% endfor %}
-        {% for termin in prosti_termini.values %}
+      {% endfor %}
+      {% for termin in prosti_termini.values %}
         {% include '_prosti_termin.html' %}
-        {% endfor %}
+      {% endfor %}
     </div>
-</div>
-<div id='informacije'>
+  </div>
+  <div id='informacije'>
     <ul class="collapsible" data-collapsible="expandable">
-        {% if nacin == 'urejanje' %}
+      {% if nacin == 'urejanje' %}
         <li>
-            <div class="collapsible-header active">
-                <i class="material-icons">inbox</i>Odložišče
-            </div>
-            <div class="collapsible-body">
-                {% for srecanje in odlozena_srecanja %}
-                {% include '_srecanje.html' with nacin='odlozisce' %}
-                {% endfor %}
-            </div>
+          <div class="collapsible-header active">
+            <i class="material-icons">inbox</i>Odložišče
+          </div>
+          <div class="collapsible-body">
+            {% for srecanje in odlozena_srecanja %}
+              {% include '_srecanje.html' with nacin='odlozisce' %}
+            {% endfor %}
+          </div>
         </li>
         {% include '_prekrivanja.html' %}
 
-        {% elif nacin == 'premikanje' %}
+      {% elif nacin == 'premikanje' %}
         <li>
-            <div class="collapsible-header active">
-                <i class="material-icons">open_with</i> Premikanje srečanja
-            </div>
-            <div class="collapsible-body">
-                {% include '_srecanje.html' with nacin='odlozisce' srecanje=premaknjeno_srecanje %}
-                <form method="post" action="{% url 'odlozi_srecanje' premaknjeno_srecanje.id %}">
-                    {% csrf_token %}
-                    <input type="hidden" name="next" value="{{ next }}">
-                    <a class="btn" style="width: 49%" href="{{ next }}">
-                        <i class="small material-icons">cancel</i>
-                    </a>
-                    <button class="btn" style="width: 49%">
-                        <i class="material-icons">move_to_inbox</i>
-                    </button>
-                </form>
-            </div>
+          <div class="collapsible-header active">
+            <i class="material-icons">open_with</i> Premikanje srečanja
+          </div>
+          <div class="collapsible-body">
+            {% include '_srecanje.html' with nacin='odlozisce' srecanje=premaknjeno_srecanje %}
+            <form method="post" action="{% url 'odlozi_srecanje' premaknjeno_srecanje.id %}">
+              {% csrf_token %}
+              <input type="hidden" name="next" value="{{ next }}">
+              <a class="btn" style="width: 49%" href="{{ next }}">
+                <i class="small material-icons">cancel</i>
+              </a>
+              <button class="btn" style="width: 49%">
+                <i class="material-icons">move_to_inbox</i>
+              </button>
+            </form>
+          </div>
         </li>
         <li>
-            <div class="collapsible-header active">
-                <i class="material-icons">line_style</i>Legenda terminov
+          <div class="collapsible-header active">
+            <i class="material-icons">line_style</i>Legenda terminov
+          </div>
+          <div class="collapsible-body">
+            <div class="legenda srecanje prosto">proste ustrezne učilnice</div>
+            <div class="legenda srecanje proste_le_alternative">deloma proste ustrezne učilnice &amp; proste
+              kompromisne učilnice
             </div>
-            <div class="collapsible-body">
-                <div class="legenda srecanje prosto">proste ustrezne učilnice</div>
-                <div class="legenda srecanje proste_le_alternative">deloma proste ustrezne učilnice &amp; proste kompromisne učilnice</div>
-                <div class="legenda srecanje deloma">deloma proste ustrezne učilnice &amp; brez kompromisnih učilnic</div>
-                <div class="legenda srecanje proste_alternative">brez ustreznih učilnic &amp; proste kompromisne učilnice</div>
-                <div class="legenda srecanje deloma_proste_alternative">brez ustreznih učilnic &amp; deloma proste kompromisne učilnice</div>
-                <div class="legenda srecanje zaseden">brez kakršnihkoli učilnic</div>
+            <div class="legenda srecanje deloma">deloma proste ustrezne učilnice &amp; brez kompromisnih učilnic</div>
+            <div class="legenda srecanje proste_alternative">brez ustreznih učilnic &amp; proste kompromisne
+              učilnice
             </div>
+            <div class="legenda srecanje deloma_proste_alternative">brez ustreznih učilnic &amp; deloma proste
+              kompromisne učilnice
+            </div>
+            <div class="legenda srecanje zaseden">brez kakršnihkoli učilnic</div>
+          </div>
         </li>
         <li>
-            <div class="collapsible-header active">
-                <i class="material-icons">line_style</i>Legenda učilnic
-            </div>
-            <div class="collapsible-body">
-                <div class="legenda srecanje ustrezna prosta">prosta ustrezna učilnica</div>
-                <div class="legenda srecanje ustrezna deloma_prosta">deloma prosta ustrezna učilnica</div>
-                <div class="legenda srecanje alternativa prosta">prosta alternativna učilnica</div>
-                <div class="legenda srecanje alternativa deloma_prosta">deloma prosta alternativna učilnica</div>
-                <div class="legenda srecanje alternativa zasedena">zasedena učilnica</div>
-            </div>
+          <div class="collapsible-header active">
+            <i class="material-icons">line_style</i>Legenda učilnic
+          </div>
+          <div class="collapsible-body">
+            <div class="legenda srecanje ustrezna prosta">prosta ustrezna učilnica</div>
+            <div class="legenda srecanje ustrezna deloma_prosta">deloma prosta ustrezna učilnica</div>
+            <div class="legenda srecanje alternativa prosta">prosta alternativna učilnica</div>
+            <div class="legenda srecanje alternativa deloma_prosta">deloma prosta alternativna učilnica</div>
+            <div class="legenda srecanje alternativa zasedena">zasedena učilnica</div>
+          </div>
         </li>
-        {% endif %}
+      {% endif %}
     </ul>
-</div>
+  </div>
 
 {% endif %}
 

--- a/urnik/templates/zacetna_stran.html
+++ b/urnik/templates/zacetna_stran.html
@@ -4,98 +4,100 @@
 <form action="{% url 'sestavljen_urnik' %}">
 <div class="container">
 <div class="row">
-    {% for letniki in stolpci_smeri %}
+  {% for letniki in stolpci_smeri %}
     <div class="col s3">
-        <table class="highlight">
-            {% regroup letniki by smer as smeri_list %}
-            {% for smer_l in smeri_list %}
-            <thead>
-                <tr>
-                    <th>{{ smer_l.grouper }}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for letnik in smer_l.list %}
-                <tr>
-                    <td style="padding: 5px">
-                        {% if izbira %}
-                        <input type="checkbox" name="letnik" value="{{ letnik.id }}" id="letnik-{{ letnik.id }}"/>
-                        <label for="letnik-{{ letnik.id }}">{{ letnik.leto }}</label>
-                        {% else %}
-                        <a href="{% url 'urnik_letnika' letnik.id %}">{{ letnik.leto }}</a>
-                        {% endif %}
-                    </td>
-                </tr>
-                {% endfor %}
-            </tbody>
-            {% endfor %}
-        </table>
+      <table class="highlight">
+        {% regroup letniki by smer as smeri_list %}
+        {% for smer_l in smeri_list %}
+          <thead>
+          <tr>
+            <th>{{ smer_l.grouper }}</th>
+          </tr>
+          </thead>
+          <tbody>
+          {% for letnik in smer_l.list %}
+            <tr>
+              <td style="padding: 5px">
+                {% if izbira %}
+                  <input type="checkbox" name="letnik" value="{{ letnik.id }}" id="letnik-{{ letnik.id }}"/>
+                  <label for="letnik-{{ letnik.id }}">{{ letnik.leto }}</label>
+                {% else %}
+                  <a href="{% url 'urnik_letnika' letnik.id %}">{{ letnik.leto }}</a>
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        {% endfor %}
+      </table>
     </div>
-    {% endfor %}
-    <div class="col s2">
-        <table class="highlight">
-            <thead>
-                <tr>
-                    <th>Učilnica</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for ucilnica in ucilnice %}
-                <tr>
-                    <td style="padding: 5px">
-                        {% if izbira %}
-                        <input type="checkbox" name="ucilnica" value="{{ ucilnica.id }}" id="ucilnica-{{ ucilnica.id }}"/>
-                        <label for="ucilnica-{{ ucilnica.id }}">{{ ucilnica.oznaka }}</label>
-                        {% else %}
-                        <a href="{% url 'urnik_ucilnice' ucilnica.id %}">{{ ucilnica.oznaka }}</a>
-                        {% endif %}
-                        <small>
-                        {% if ucilnica.tip == ucilnica.RACUNALNISKA %}
-                        <i class="tiny material-icons">computer</i>
-                        {% elif ucilnica.tip == ucilnica.PRAKTIKUM %}
-                        <i class="tiny material-icons">build</i>
-                        {% endif %}
-                        ({{ ucilnica.velikost|default:'?' }} mest)</small>
-                    </td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+  {% endfor %}
+  <div class="col s2">
+    <table class="highlight">
+      <thead>
+      <tr>
+        <th>Učilnica</th>
+      </tr>
+      </thead>
+      <tbody>
+      {% for ucilnica in ucilnice %}
+        <tr>
+          <td style="padding: 5px">
+            {% if izbira %}
+              <input type="checkbox" name="ucilnica" value="{{ ucilnica.id }}" id="ucilnica-{{ ucilnica.id }}"/>
+              <label for="ucilnica-{{ ucilnica.id }}">{{ ucilnica.oznaka }}</label>
+            {% else %}
+              <a href="{% url 'urnik_ucilnice' ucilnica.id %}">{{ ucilnica.oznaka }}</a>
+            {% endif %}
+            <small>
+              {% if ucilnica.tip == ucilnica.RACUNALNISKA %}
+                <i class="tiny material-icons">computer</i>
+              {% elif ucilnica.tip == ucilnica.PRAKTIKUM %}
+                <i class="tiny material-icons">build</i>
+              {% endif %}
+              ({{ ucilnica.velikost|default:'?' }} mest)
+            </small>
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <div class="col s4" style="position: relative">
+    <div style="position: absolute; right: 0; top: 8px">
+      {% if izbira %}
+        <button class="btn-flat"><i class="material-icons left">playlist_play</i>prikaži</button>
+      {% else %}
+        <a class="btn-flat" href="{% url 'zacetna_stran' %}?izbira"><i class="material-icons left">playlist_add_check</i>označi
+          več</a>
+      {% endif %}
     </div>
-    <div class="col s4" style="position: relative">
-        <div style="position: absolute; right: 0; top: 8px">
-        {% if izbira %}
-            <button class="btn-flat"><i class="material-icons left">playlist_play</i>prikaži</button>
-        {% else %}
-            <a class="btn-flat" href="{% url 'zacetna_stran' %}?izbira"><i class="material-icons left">playlist_add_check</i>označi več</a>
-        {% endif %}
-        </div>
-        <table class="highlight">
-            <thead>
-                <tr>
-                    <th>Oseba</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for oseba in osebe %}
-                <tr>
-                    <td style="padding: 5px">
-                        {% if izbira %}
-                        <input type="checkbox" name="oseba" value="{{ oseba.id }}" id="oseba-{{ oseba.id }}"/>
-                        <label for="oseba-{{ oseba.id }}">{{ oseba.ime }} <strong>{{ oseba.priimek }}</strong></label>
-                        {% else %}
-                        <a href="{% url 'urnik_osebe' oseba.id %}">
-                            {{ oseba.ime }} <strong>{{ oseba.priimek }}</strong>
-                        </a>
-                        {% endif %}
-                    </td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-</div>
-</div>
+    <table class="highlight">
+      <thead>
+      <tr>
+        <th>Oseba</th>
+      </tr>
+      </thead>
+      <tbody>
+      {% for oseba in osebe %}
+        <tr>
+          <td style="padding: 5px">
+            {% if izbira %}
+              <input type="checkbox" name="oseba" value="{{ oseba.id }}" id="oseba-{{ oseba.id }}"/>
+              <label for="oseba-{{ oseba.id }}">{{ oseba.ime }} <strong>{{ oseba.priimek }}</strong></label>
+            {% else %}
+              <a href="{% url 'urnik_osebe' oseba.id %}">
+                {{ oseba.ime }} <strong>{{ oseba.priimek }}</strong>
+              </a>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div> <!-- row -->
+</div> <!-- container -->
 </form>
 
 {% endblock content %}

--- a/urnik/templates/zacetna_stran.html
+++ b/urnik/templates/zacetna_stran.html
@@ -4,8 +4,15 @@
 <form action="{% url 'sestavljen_urnik' %}">
 <div class="container">
 <div class="row">
+  <div class="oznaci-vec">
+    {% if izbira %}
+      <button class="btn-flat" href="#!"><i class="material-icons left">playlist_play</i>prikaži</button>
+    {% else %}
+      <a class="btn-flat" href="{% url 'zacetna_stran' %}?izbira"><i class="material-icons left">playlist_add_check</i>označi več</a>
+    {% endif %}
+  </div>  <!-- oznaci vec -->
   {% for letniki in stolpci_smeri %}
-    <div class="col s3">
+    <div class="col s6 m3">
       <table class="highlight">
         {% regroup letniki by smer as smeri_list %}
         {% for smer_l in smeri_list %}
@@ -17,7 +24,7 @@
           <tbody>
           {% for letnik in smer_l.list %}
             <tr>
-              <td style="padding: 5px">
+              <td class="padded">
                 {% if izbira %}
                   <input type="checkbox" name="letnik" value="{{ letnik.id }}" id="letnik-{{ letnik.id }}"/>
                   <label for="letnik-{{ letnik.id }}">{{ letnik.leto }}</label>
@@ -30,9 +37,9 @@
           </tbody>
         {% endfor %}
       </table>
-    </div>
+    </div>  <!-- smeri -->
   {% endfor %}
-  <div class="col s2">
+  <div class="col s6 m3">
     <table class="highlight">
       <thead>
       <tr>
@@ -42,7 +49,7 @@
       <tbody>
       {% for ucilnica in ucilnice %}
         <tr>
-          <td style="padding: 5px">
+          <td class="padded">
             {% if izbira %}
               <input type="checkbox" name="ucilnica" value="{{ ucilnica.id }}" id="ucilnica-{{ ucilnica.id }}"/>
               <label for="ucilnica-{{ ucilnica.id }}">{{ ucilnica.oznaka }}</label>
@@ -62,16 +69,8 @@
       {% endfor %}
       </tbody>
     </table>
-  </div>
-  <div class="col s4" style="position: relative">
-    <div style="position: absolute; right: 0; top: 8px">
-      {% if izbira %}
-        <button class="btn-flat"><i class="material-icons left">playlist_play</i>prikaži</button>
-      {% else %}
-        <a class="btn-flat" href="{% url 'zacetna_stran' %}?izbira"><i class="material-icons left">playlist_add_check</i>označi
-          več</a>
-      {% endif %}
-    </div>
+  </div> <!-- ucilnice -->
+  <div class="col s6 m3">
     <table class="highlight">
       <thead>
       <tr>
@@ -81,7 +80,7 @@
       <tbody>
       {% for oseba in osebe %}
         <tr>
-          <td style="padding: 5px">
+          <td class="padded">
             {% if izbira %}
               <input type="checkbox" name="oseba" value="{{ oseba.id }}" id="oseba-{{ oseba.id }}"/>
               <label for="oseba-{{ oseba.id }}">{{ oseba.ime }} <strong>{{ oseba.priimek }}</strong></label>
@@ -95,7 +94,7 @@
       {% endfor %}
       </tbody>
     </table>
-  </div>
+  </div>  <!-- osebe -->
 </div> <!-- row -->
 </div> <!-- container -->
 </form>

--- a/urnik/templates/zacetna_stran.html
+++ b/urnik/templates/zacetna_stran.html
@@ -39,7 +39,7 @@
       </table>
     </div>  <!-- smeri -->
   {% endfor %}
-  <div class="col s6 m3">
+  <div class="col s6 m2">
     <table class="highlight">
       <thead>
       <tr>
@@ -70,7 +70,7 @@
       </tbody>
     </table>
   </div> <!-- ucilnice -->
-  <div class="col s6 m3">
+  <div class="col s6 m4">
     <table class="highlight">
       <thead>
       <tr>


### PR DESCRIPTION
Vem da je velik pull request. Let me break it up:

**General**
- v osnova.html sem popravil značke da so pravilno gnezdene (nek <ul> ni bil zaprt)
- zgornji meni se collapsa na smaller and less screen sizes in se pojavi stranski meni z enako vsebino (zato sem factoral out meni v poseben templte)
- na majhnih zaslonih se skrije tvoje ime, če si loggan in
- dropdown meni sem popravil, tako da se pojavi na dnu objekta, ki ga je triggeral in da nima omejene širine, 
  ker sicer je zgledal grozno
- zraven ikone za oko ali svinčnika sem dodal carret, ki indicata da je tukaj dropdown
- naslovi zdaj nikoli ne skočijo v več kot eno vrstico, ampak pač gredo offscreen (treba bi bilo razmislit o tem, da bi vsaj naslov imel "short" verzijo iz ene same besede npr.)


<img src="https://user-images.githubusercontent.com/1394590/32272947-a2dbab96-bf00-11e7-966e-5da11468430b.png" width="300">
<img src="https://user-images.githubusercontent.com/1394590/32272953-a9f495a0-bf00-11e7-8096-2ee363daafa9.png" width="300">

**Front page:**
- stolpci se na small collapsajo drug pod drugega tako da ostaneta skupaj 2 (z razliko od 4ih zdaj)
- zato da se pravilno pokaže na mobilni strani, sem gumb "označi več" vzel ven iz stolpcev in ga premaknil na vrh htmlja, lokacija na strani pa ostaja enaka
- tisti container, ki je bil stiliziran ročno sem moral dat stran, sicer se stvari niso v redu podrle

Desktop (prej / potem):
<img src="https://user-images.githubusercontent.com/1394590/32273004-e92c1c52-bf00-11e7-8e6f-878c4e6b543c.png" width="500">
<img src="https://user-images.githubusercontent.com/1394590/32273006-eb2323f2-bf00-11e7-855c-56abc930b9ff.png" width="500">

Mobile (prej / potem):
<img src="https://user-images.githubusercontent.com/1394590/32273105-521d35ac-bf01-11e7-9d6b-524ca935ddba.png" width="290"><img src="https://user-images.githubusercontent.com/1394590/32273100-4d447c8e-bf01-11e7-9a88-b5cc03690c93.png" width="290">

Tale gumb označi več je v resnici element podmenija glavne strani, zdelo se mi je out of scope tega requesta reševat problem z njegovo pozicijo, ker je to vprašanje treba bolje razmislit skupaj s problemom dodajanja novih gumbov. 

**Rezervacije**
Tukaj ni bilo večjih sprememb, ker je odstranitev zunanjega containerja vse pofixala.
ps: za ikono rezervacij priporočam: https://material.io/icons/#ic_event_available namesto "edit" ikone
Desktop (prej / potem):
<img src="https://user-images.githubusercontent.com/1394590/32272910-7ac17618-bf00-11e7-97a5-d167c20a7424.png" width="500">
<img src="https://user-images.githubusercontent.com/1394590/32272912-7c45b7ce-bf00-11e7-8ab7-c651c5f09e92.png" width="500">

Mobile (prej / potem):
<img src="https://user-images.githubusercontent.com/1394590/32272820-22a9fcde-bf00-11e7-9fcf-07eec5d60c89.png" width="300"><img src="https://user-images.githubusercontent.com/1394590/32272856-43d35c52-bf00-11e7-8a1a-a438e26ea8fc.png" width="300"> 

**Urnik**
- to je edina stran, kjer rabimo tisti zunanji container, tako da sem dodal urnik-wraper, 
  ki poskrbi za dovolj velik prazen prostor. Če je urnik cel, potem je širina 95%, ce pa ima legendo / edit na desni pa 80% kot prej.
- obdržal sem smiselne min-width in min-height nastavitve, se pa urnik zdaj lahko poljubno raztegne v višino in širino. Lahko dodamo tudi max-height nastavitve.
- na majhnih zaslonih gre urnik prek zaslona (kar tudi zelimo) ampak kljub temu želimo dovoliti, da uporabnik zooma out tako da na 
  majhno vidi cel urnik. Zato sem dodal vertical spacer, da je stran dovolj dolga, da jo lahko odzoomamo toliko, da se vidi cel urnik.
- pri sestavljenem urniku in edit mode-u so v stari verziji breakali margini, kar se je zdaj avtomatsko popravilo, edina razlika je v širini urnika
- pri information boxu sem malo zmanjšal padding, tako da so tisti seznami konfliktov malo krajši in malo bolj pregledni

Desktop (prej / potem):
<img src="https://user-images.githubusercontent.com/1394590/32273238-e971cd28-bf01-11e7-9c73-5888a423a639.png" width="500">
<img src="https://user-images.githubusercontent.com/1394590/32273241-eb65ef4c-bf01-11e7-99df-f34091cb1ff8.png" width="500">

Mobile (prej / potem / potem zoom out / potem landscape):
<img src="https://user-images.githubusercontent.com/1394590/32273435-cc853faa-bf02-11e7-8c18-ed19b322440d.png" width="300"><img src="https://user-images.githubusercontent.com/1394590/32273437-ce41f9f0-bf02-11e7-9e96-246beb222f19.png" width="300"><img src="https://user-images.githubusercontent.com/1394590/32273446-d1f1d34a-bf02-11e7-8a33-8263bbd9ea5a.png" width="300">
<img src="https://user-images.githubusercontent.com/1394590/32273450-d4abd32e-bf02-11e7-9c83-a50e94d6a827.png" width="500">

Stran še ni popolna, ampak je precej boljše. Predvsem na naslovih in samih boxih, ki opisujejo srečanja, bi se dalo še veliko narediti. Pa seveda tisti označi več.