### PR TITLE
Kazalo na stran z odprtimi zadevami

### DIFF
--- a/urnik/static/stil.css
+++ b/urnik/static/stil.css
@@ -387,7 +387,7 @@ a.skrita {
 }
 
 #bug-report ul {
-    bottom: 48px;
+    bottom: 54px;
     left: -160px;
     text-align: right;
     background-color: #fff;
@@ -395,4 +395,23 @@ a.skrita {
 
 #bug-report > a > i {
     font-size: 2rem;
+}
+
+#bug-report #cancel-bug-report {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    display: none;
+    background-color: white;
+    color: #26a69a;
+    border-radius: 12px;
+    z-index: 998;
+    height: 24px;
+    width: 24px;
+    box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14),0 1px 5px 0 rgba(0,0,0,0.12),0 3px 1px -2px rgba(0,0,0,0.2);
+    cursor: pointer;
+}
+
+#bug-report:hover #cancel-bug-report {
+    display: block;
 }

--- a/urnik/static/stil.css
+++ b/urnik/static/stil.css
@@ -380,3 +380,19 @@ a.skrita {
 #search-osebe-wrapper ul.autocomplete-content li > span > span.highlight {
     color: #039be5;
 }
+
+#bug-report {
+    bottom: 15px;
+    right: 15px;
+}
+
+#bug-report ul {
+    bottom: 48px;
+    left: -160px;
+    text-align: right;
+    background-color: #fff;
+}
+
+#bug-report > a > i {
+    font-size: 2rem;
+}

--- a/urnik/templates/osnova.html
+++ b/urnik/templates/osnova.html
@@ -56,6 +56,19 @@
   {% include "navigation.html" %}
 </ul> <!-- side nav -->
 
+<div class="fixed-action-btn hide-on-small-and-down" id="bug-report"><!-- bottom right report button -->
+  <a class="btn-floating btn-large" href="https://github.com/ul-fmf/urnik/issues">
+    <i class="large large material-icons">thumbs_up_down</i>
+  </a>
+  <ul>
+    <li>Seznam želja in napak lahko najdete na <a href="https://github.com/ul-fmf/urnik/issues">GitHub-u</a>. Če želite
+      sporočiti željo ali napako, ki je še ni na seznamu, jo pošljite na mail
+      <a href="mailto:matija.pretnar@fmf.uni-lj.si">matija.pretnar@fmf.uni-lj.si</a> ali pa se prijavite na GitHub
+      in jo vpišite kar sami &ndash; v tem primeru lahko tudi sodelujete v diskusiji.
+    </li>
+  </ul>
+</div>
+
 {% block content %}{% endblock content %}
 
 <script type="text/javascript" src="//code.jquery.com/jquery-2.1.1.min.js"></script>

--- a/urnik/templates/osnova.html
+++ b/urnik/templates/osnova.html
@@ -67,6 +67,7 @@
       in jo vpišite kar sami &ndash; v tem primeru lahko tudi sodelujete v diskusiji.
     </li>
   </ul>
+  <div id="cancel-bug-report" onclick="$('#bug-report').hide();"><i class="material-icons">close</i></div>
 </div>
 
 {% block content %}{% endblock content %}


### PR DESCRIPTION
Kot opisano v #12 sem dodal gumb, ki pove uporabniku, da vemo za veliko njegovih težav. Je viden na vseh straneh spodaj v kotu, razen na telefonu. Closes #12.

![image](https://user-images.githubusercontent.com/1394590/33232673-796f14ec-d20a-11e7-8e09-bb23ec17ce08.png)

![image](https://user-images.githubusercontent.com/1394590/33232693-9e8b3314-d20a-11e7-801f-4831dbdd2655.png)

