### PR TITLE
Fix crash when dealing with meetings not in timetable.

### DIFF
--- a/urnik/models.py
+++ b/urnik/models.py
@@ -351,7 +351,7 @@ class Srecanje(models.Model):
         return self.dan and self.ura
 
     def po_potrebi_okrajsano_ime_predmeta(self):
-        if 'sirina' in vars(self) and ((self.sirina >= 0.5 and len(self.predmet.ime) < 45 and self.trajanje > 1) or self.sirina == 1):
+        if hasattr(self, 'sirina') and ((self.sirina >= 0.5 and len(self.predmet.ime) < 45 and self.trajanje > 1) or self.sirina == 1):
             return self.predmet.ime
         else:
             return self.predmet.kratica
@@ -365,7 +365,7 @@ class Srecanje(models.Model):
         ).distinct()
 
     def style(self):
-        if self.dan and self.ura and 'sirina' in vars(self):
+        if self.dan and self.ura and hasattr(self, 'sirina'):
             left = (self.dan - 1 + self.zamik) * ENOTA_SIRINE
             top = (self.ura - MIN_URA) * ENOTA_VISINE
             height = self.trajanje * ENOTA_VISINE
@@ -377,8 +377,8 @@ class Srecanje(models.Model):
 
     def css_classes(self):
         classes = []
-        if self.leftmost: classes.append('leftmost')
-        if self.rightmost: classes.append('rightmost')
+        if hasattr(self, 'leftmost') and self.leftmost: classes.append('leftmost')
+        if hasattr(self, 'rightmost') and self.rightmost: classes.append('rightmost')
         return ' '.join(classes)
 
 

--- a/urnik/static/stil.css
+++ b/urnik/static/stil.css
@@ -136,9 +136,9 @@ nav {
 .srecanje a:hover, .urejanje a {
     color: #039be5;
 }
-#informacije .srecanje {
+#informacije .srecanje-absolute-box {
     position: relative;
-    height: 4em;
+    height: 70px;
 }
 a.skrita {
     color: #555;
@@ -153,7 +153,7 @@ a.skrita {
 .ucitelj, .ucilnica {
     font-size: 0.8em;
     position: absolute;
-    bottom: 4pt;
+    bottom: 2pt;
     z-index: 10;
 }
 .ucilnica {


### PR DESCRIPTION
Popravi regression povzrocen v #21 ker sem pri generiranju dodal atributa `leftmost` in `rightmost` kot sta ze bila `sirina` in `zamik`. Pozabil pa sem , da nista vedno prisotna in zato trenutna verzija urnika crasha, ko poskusas premaknit, odložit ali kakorkoli uporabljat srečanje, ki ni v urniku ampak je samostojno. 
Pa zamenjal sem tiste `vars`v `hasattr` in popravil tudi manjsi regression v stilu, ko so bila odložena srečanja prikazana out of the box.

Na splošno se tole dinamično dodajanje atrbutov ne zdi najboljši dizajn, ampak zdaj pač je kot je.
