### PR TITLE
Napaka ob izbiranju trenutnega semestra

### DIFF
--- a/urnik/views.py
+++ b/urnik/views.py
@@ -32,7 +32,8 @@ def izberi_semester(request, semester_id=None):
         semester_id = get_object_or_404(Semester, id=semester_id)
         request.session['semester_id'] = semester_id.id
     else:
-        del request.session['semester_id']
+        if 'semester_id' in request.session:
+            del request.session['semester_id']
     return redirect(reverse('zacetna_stran'))
 
 def zacetna_stran(request):


### PR DESCRIPTION
Closes #71.

Mimogrede, a ne bi bilo bolje, da se semester izbere eksplicitno v URL-ju in ne s piškotki? Tako bi npr. link na moj urnik vedno kazal na aktualen urnik in ne na urnik v tistem semestru, ki sem ga pač zadnjega gledal.