### PR TITLE
Izbira semestra premaknjena v URL

### DIFF
--- a/project/urls.py
+++ b/project/urls.py
@@ -14,46 +14,10 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 from django.conf import settings
-from django.contrib import admin
-from django.contrib.auth import views as auth_views
-from django.urls import path, re_path, include
-
-import urnik.views
+from django.urls import path, include
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('login/', auth_views.LoginView.as_view(template_name='login.html'), name='login'),
-    path('logout/', auth_views.LogoutView.as_view(), name='logout'),
-    path('', urnik.views.zacetna_stran, name='zacetna_stran'),
-    path('urnik/', urnik.views.kombiniran_pogled, name='kombiniran_pogled'),
-    path('kombiniran/', urnik.views.kombiniran_pogled_form, name='kombiniran_pogled_form'),
-    path('rezervacije/', urnik.views.rezervacije, name='rezervacije'),
-    path('nova-rezervacija/', urnik.views.nova_rezervacija, name='nova_rezervacija'),
-    re_path(r'^nova-rezervacija/(?P<ucilnica_id>\d+)/(?P<ura>\d+)/(?P<teden>[0-9-]*)/(?P<dan_v_tednu>[0-6])/$',
-            urnik.views.nova_rezervacija, name='nova_rezervacija_za_ucilnico'),
-    path('preglej-rezervacije/', urnik.views.preglej_rezervacije, name='preglej_rezervacije'),
-    path('potrdi-rezervacijo/', urnik.views.potrdi_rezervacijo, name='potrdi_rezervacijo'),
-    path('potrdi-vse-rezervacije/', urnik.views.potrdi_vse_rezervacije, name='potrdi_vse_rezervacije'),
-    path('izbrisi-rezervacijo/', urnik.views.izbrisi_rezervacijo, name='izbrisi_rezervacijo'),
-    path('proste/', urnik.views.proste_ucilnice, name='proste'),
-    path('proste_filter/', urnik.views.proste_ucilnice_filter, name='proste_filter'),
-    path('oseba/<int:oseba_id>/', urnik.views.urnik_osebe, name='urnik_osebe'),
-    path('letnik/<int:letnik_id>/', urnik.views.urnik_letnika, name='urnik_letnika'),
-    path('ucilnica/<int:ucilnica_id>/', urnik.views.urnik_ucilnice, name='urnik_ucilnice'),
-    path('predmet/<int:predmet_id>/', urnik.views.urnik_predmeta, name='urnik_predmeta'),
-    path('srecanje/<int:srecanje_id>/premakni/', urnik.views.premakni_srecanje, name='premakni_srecanje'),
-    path('srecanje/<int:srecanje_id>/podvoji/', urnik.views.podvoji_srecanje, name='podvoji_srecanje'),
-    path('srecanje/<int:srecanje_id>/odlozi/', urnik.views.odlozi_srecanje, name='odlozi_srecanje'),
-    path('srecanje/<int:srecanje_id>/trajanje/', urnik.views.nastavi_trajanje_srecanja, name='nastavi_trajanje_srecanja'),
-    path('preklopi_urejanje/', urnik.views.preklopi_urejanje, name='preklopi_urejanje'),
-    path('izberi-semester/', urnik.views.izbira_semestra, name='izbira_semestra'),
-    path('izberi-semester/<int:semester_id>/', urnik.views.izberi_semester, name='izberi_semester'),
-    path('izberi-semester/trenutni/', urnik.views.izberi_semester, name='izberi_trenutni_semester'),
-    path('bugreport/', urnik.views.bug_report, name='bugreport'),
-    path('help/', urnik.views.help_page, name='help'),
-    path('printall/', urnik.views.print_all, name='printall'),
-    re_path(r'^printall/ucilnice/(?P<oddelek>[MF])/$', urnik.views.print_all_ucilnice, name='printall_ucilnice'),
-    re_path(r'^printall/smeri/(?P<oddelek>[MF])/$', urnik.views.print_all_smeri, name='printall_smeri'),
+    path('', include('urnik.urls')),
 ]
 
 if 'silk' in settings.INSTALLED_APPS:

--- a/urnik/context_preprocessors.py
+++ b/urnik/context_preprocessors.py
@@ -13,4 +13,5 @@ def izbrani_semester(request):
     return {
         'izbrani_semester': views.izbrani_semester(request),
         'ogled_starega_semestra': views.ogled_starega_semestra(request),
+        'izbrani_semester_id': views.izbrani_semester_id(request),
     }

--- a/urnik/semester_urls.py
+++ b/urnik/semester_urls.py
@@ -1,0 +1,18 @@
+from django.urls import path, re_path, include
+
+import urnik.views
+
+urlpatterns = [
+    path('', urnik.views.zacetna_stran, name='zacetna_stran'),
+    path('urnik/', urnik.views.kombiniran_pogled, name='kombiniran_pogled'),
+    path('kombiniran/', urnik.views.kombiniran_pogled_form, name='kombiniran_pogled_form'),
+    path('proste/', urnik.views.proste_ucilnice, name='proste'),
+    path('proste_filter/', urnik.views.proste_ucilnice_filter, name='proste_filter'),
+    path('oseba/<int:oseba_id>/', urnik.views.urnik_osebe, name='urnik_osebe'),
+    path('letnik/<int:letnik_id>/', urnik.views.urnik_letnika, name='urnik_letnika'),
+    path('ucilnica/<int:ucilnica_id>/', urnik.views.urnik_ucilnice, name='urnik_ucilnice'),
+    path('predmet/<int:predmet_id>/', urnik.views.urnik_predmeta, name='urnik_predmeta'),
+    path('printall/', urnik.views.print_all, name='printall'),
+    re_path(r'^printall/ucilnice/(?P<oddelek>[MF])/$', urnik.views.print_all_ucilnice, name='printall_ucilnice'),
+    re_path(r'^printall/smeri/(?P<oddelek>[MF])/$', urnik.views.print_all_smeri, name='printall_smeri'),
+]

--- a/urnik/static/stil.css
+++ b/urnik/static/stil.css
@@ -89,6 +89,26 @@ dt {
 nav {
     background-color: #555;
 }
+nav.old-semester {
+    background: repeating-linear-gradient( -45deg, #555, #555 10px, #666 10px, #666 20px);
+    color: #000;
+}
+#old-semester-note {
+    position: fixed;
+    padding: 5px 10px;
+    top: 65px;
+    right: 6px;
+    width: 150px;
+    z-index: 2;
+}
+.card i.close-icon {
+    position: absolute;
+    cursor: pointer;
+    font-size: 12pt;
+    top: 5px;
+    right: 5px;
+}
+@media only screen and (max-width: 600px) { #old-semester-note { top: 57px; } }
 
 #urnik-logo {
     white-space: nowrap;
@@ -943,3 +963,4 @@ table.highlight tr th {
 .cancel.btn:active {
     background-color: #f44336;
 }
+

--- a/urnik/templates/_proste_ucilnice_za_termin.html
+++ b/urnik/templates/_proste_ucilnice_za_termin.html
@@ -6,12 +6,12 @@
       {% for stanje, ucilnica, razlog in termin.prikazane_ucilnice %}
         <span class="ucilnica ucilnica-id-{{ ucilnica.pk }} ucilnica-stanje-{{ stanje }}">
           <span class="ucilnica-ime">
-            <a href="{% url 'urnik_ucilnice' ucilnica.pk %}">
+            <a href="{% url 'urnik_ucilnice' ucilnica_id=ucilnica.pk semester_id=izbrani_semester_id %}">
               {{ ucilnica.kratko_ime }}</a></span>{% if not forloop.last %},{% endif %}
           <span class="hover-area"></span>
           <span class="ucilnica-tooltip">
             {% if stanje == 'prosta' %}
-              <a href="{% url 'urnik_ucilnice' ucilnica.pk %}">Učilnica {{ ucilnica.oznaka }}</a>
+              <a href="{% url 'urnik_ucilnice' ucilnica_id=ucilnica.pk semester_id=izbrani_semester_id %}">Učilnica {{ ucilnica.oznaka }}</a>
               je prosta v {{ termin.dan|dan_tozilnik }} ob {{ termin.ura }}ih.
               {% if user.is_authenticated %}
                 <a href="{% url 'nova_rezervacija_za_ucilnico' ucilnica.pk termin.ura teden|date:"Y-m-d"|default:"-" termin.dan %}"
@@ -19,21 +19,21 @@
                 Rezerviraj <i class="material-icons">open_in_new</i></a>
               {% endif %}
             {% elif stanje == 'rezervirana' %}
-              <a href="{% url 'urnik_ucilnice' ucilnica.pk %}">Učilnico {{ ucilnica.oznaka }}</a>
+              <a href="{% url 'urnik_ucilnice' ucilnica_id=ucilnica.pk semester_id=izbrani_semester_id %}">Učilnico {{ ucilnica.oznaka }}</a>
               je od {{ razlog.od }}ih do {{ razlog.do }}ih rezervirala oseba
               {% if razlog.osebe.all.0 %}
-                <a href="{% url 'urnik_osebe' razlog.osebe.all.0.pk %}">{{ razlog.osebe.all.0 }}</a>
+                <a href="{% url 'urnik_osebe' oseba_id=razlog.osebe.all.0.pk semester_id=izbrani_semester_id %}">{{ razlog.osebe.all.0 }}</a>
               {% else %}
                 neznan
               {% endif %}
               z razlogom: &quot;{{ razlog.opomba|default:"neznan" }}&quot;.
             {% elif stanje == 'zasedena' %}
-              <a href="{% url 'urnik_ucilnice' ucilnica.pk %}">Učilnica {{ ucilnica.oznaka }}</a>
+              <a href="{% url 'urnik_ucilnice' ucilnica_id=ucilnica.pk semester_id=izbrani_semester_id %}">Učilnica {{ ucilnica.oznaka }}</a>
               je zasedena ob {{ razlog.dan | dan_tozilnik_mnozina }} ob {{ razlog.ura }}ih
-              saj tam poteka predmet <a href="{% url 'urnik_predmeta' razlog.predmet.pk %}">
+              saj tam poteka predmet <a href="{% url 'urnik_predmeta' predmet_id=razlog.predmet.pk semester_id=izbrani_semester_id %}">
               {{ razlog.predmet }}</a>, ki ga izvaja
               {% if razlog.ucitelji.all.0 %}
-                <a href="{% url 'urnik_osebe' razlog.ucitelji.all.0.pk %}">{{ razlog.ucitelji.all.0 }}</a>.
+                <a href="{% url 'urnik_osebe' oseba_id=razlog.ucitelji.all.0.pk semester_id=izbrani_semester_id %}">{{ razlog.ucitelji.all.0 }}</a>.
               {% else %}
                 neznana oseba.
               {% endif %}

--- a/urnik/templates/_srecanje.html
+++ b/urnik/templates/_srecanje.html
@@ -6,7 +6,7 @@
 {#    <div class="info-box"><i class="material-icons">info_outline</i></div> #}
     <span class="predmet">
       {% if srecanje.predmet %}
-        <a href="{% url 'urnik_predmeta' srecanje.predmet.id %}">
+        <a href="{% url 'urnik_predmeta' predmet_id=srecanje.predmet.id semester_id=izbrani_semester_id %}">
           {% if nacin == 'ogled' %}{{ srecanje.po_potrebi_okrajsano_ime_predmeta }}{% else %}{{ srecanje.predmet.kratica }}{% endif %}
         </a>
       {% endif %}
@@ -18,7 +18,7 @@
     {% if srecanje.trajanje > 1 %}
     <span class="letniki">
       {% for letnik in srecanje.predmet.letniki.all %}
-        <a href="{% url 'urnik_letnika' letnik.id %}">{{ letnik.kratica }}</a>{% if not forloop.last %}, {% endif %}
+        <a href="{% url 'urnik_letnika' letnik_id=letnik.id semester_id=izbrani_semester_id %}">{{ letnik.kratica }}</a>{% if not forloop.last %}, {% endif %}
       {% endfor %}
     </span>
     {% endif %}
@@ -26,13 +26,13 @@
 
   <div class="ucitelj">
     {% for ucitelj in srecanje.ucitelji.all %}
-      <a href="{% url 'urnik_osebe' ucitelj.id %}">{{ ucitelj.priimek }}</a>{% if not forloop.last %}, {% endif %}
+      <a href="{% url 'urnik_osebe' oseba_id=ucitelj.id semester_id=izbrani_semester_id %}">{{ ucitelj.priimek }}</a>{% if not forloop.last %}, {% endif %}
     {% endfor %}
   </div>
 
   {% if srecanje.ucilnica %}
     <div class="ucilnica">
-      <a href="{% url 'urnik_ucilnice' srecanje.ucilnica.id %}">{{ srecanje.ucilnica.kratko_ime }}</a>
+      <a href="{% url 'urnik_ucilnice' ucilnica_id=srecanje.ucilnica.id semester_id=izbrani_semester_id %}">{{ srecanje.ucilnica.kratko_ime }}</a>
     </div>
   {% endif %}
 

--- a/urnik/templates/izbira_semestra.html
+++ b/urnik/templates/izbira_semestra.html
@@ -8,7 +8,7 @@
   <ul>
     {% for semester in semestri %}
     <li>
-      {% if forloop.counter == semestri|length %}
+      {% if forloop.last %}
       <a href="{% url 'zacetna_stran' %}">{{ semester }}</a> – trenutni semester
       {% else %}
       <a href="{% url 'zacetna_stran' semester.pk %}">{{ semester }}</a>

--- a/urnik/templates/izbira_semestra.html
+++ b/urnik/templates/izbira_semestra.html
@@ -2,19 +2,17 @@
 {% load tags %}
 {% block content %}
 <div class="container">
-
-<p class="flow-text">
-  Izberite semester, za katerega si želite ogledati urnike:
-  <ul>
-    {% for semester in semestri %}
-    <li>
-      {% if forloop.last %}
-      <a href="{% url 'zacetna_stran' %}">{{ semester }}</a> – trenutni semester
+  <p class="flow-text">Izberite semester, za katerega si želite ogledati urnike:</p>
+  <ul class="collection">
+    {% for semester in semestri.reverse %}
+    <li class="collection-item">
+      {% if forloop.first %}
+      <a href="{% url 'zacetna_stran' %}">{{ semester }}</a> &ndash; trenutni semester
       {% else %}
       <a href="{% url 'zacetna_stran' semester.pk %}">{{ semester }}</a>
       {% endif %}
     </li>
     {% endfor %}
   </ul>
-</p>
+</div>
 {% endblock content %}

--- a/urnik/templates/izbira_semestra.html
+++ b/urnik/templates/izbira_semestra.html
@@ -9,9 +9,9 @@
     {% for semester in semestri %}
     <li>
       {% if forloop.counter == semestri|length %}
-      <a href="{% url 'izberi_trenutni_semester' %}">{{ semester }}</a> – trenutni semester
+      <a href="{% url 'zacetna_stran' %}">{{ semester }}</a> – trenutni semester
       {% else %}
-      <a href="{% url 'izberi_semester' semester.pk %}">{{ semester }}</a>
+      <a href="{% url 'zacetna_stran' semester.pk %}">{{ semester }}</a>
       {% endif %}
     </li>
     {% endfor %}

--- a/urnik/templates/kombiniran_pogled.html
+++ b/urnik/templates/kombiniran_pogled.html
@@ -1,7 +1,7 @@
 {% extends 'osnova.html' %}
 {% block content %}
 
-<form action="{% url 'kombiniran_pogled' %}" id="kombiniran-pogled-form">
+<form action="{% url 'kombiniran_pogled' semester_id=izbrani_semester_id %}" id="kombiniran-pogled-form">
 <div class="container">
 <div class="row">
   <div class="col m12">

--- a/urnik/templates/osnova.html
+++ b/urnik/templates/osnova.html
@@ -97,6 +97,7 @@
 <ul class="sidenav" id="side-menu"> <!-- side navigation -->
   <li><a href="{% url 'zacetna_stran' semester_id=izbrani_semester_id %}"><i class="material-icons left">home</i>Domov</a></li>
   <li><a href="{% url 'kombiniran_pogled_form' semester_id=izbrani_semester_id %}"><i class="material-icons left">schedule</i>Kombiniran pogled</a></li>
+  {% if not ogled_starega_semestra %}
   <li><a href="{% url 'rezervacije' %}"><i class="material-icons left">border_color</i>Rezervacije učilnic</a></li>
   <li><a href="{% url 'proste' semester_id=izbrani_semester_id %}"><i class="material-icons left">event_available</i>Proste učilnice</a></li>
   {% if user.is_authenticated %}
@@ -104,6 +105,7 @@
   {% endif %}
   {% if user.is_staff %}
     <li><a href="{% url 'preglej_rezervacije' %}"><i class="material-icons left">visibility</i>Preglej nove rezervacije</a></li>
+  {% endif %}
   {% endif %}
   <li><a href="javascript:window.print();"><i class="material-icons left">print</i>Natisni stran</a></li>
   {% if user.is_staff %}
@@ -127,12 +129,16 @@
     var search_urls = {
         "Meni: Urnik": "{% url 'zacetna_stran' semester_id=izbrani_semester_id %}",
         "Meni: Kombiniran pogled": "{% url 'kombiniran_pogled_form' semester_id=izbrani_semester_id %}",
+    {% if not ogled_starega_semestra %}
         "Meni: Rezervacije učilnic": "{% url 'rezervacije' %}",
     {% if user.is_authenticated %}
         "Meni: Nova rezervacija": "{% url 'nova_rezervacija' %}",
     {% endif %}
     {% if user.is_staff %}
         "Meni: Preglej nove rezervacije": "{% url 'preglej_rezervacije' %}",
+    {% endif %}
+    {% endif %}
+    {% if user.is_staff %}
         "Meni: Natisni vse": "{% url 'printall' semester_id=izbrani_semester_id %}",
     {% endif %}
         "Meni: Proste učilnice": "{% url 'proste' semester_id=izbrani_semester_id %}",

--- a/urnik/templates/osnova.html
+++ b/urnik/templates/osnova.html
@@ -24,10 +24,10 @@
 
 <body>
 <div class="navbar-fixed">
-  <nav>
+  <nav class="{{ ogled_starega_semestra|yesno:"old-semester,current-semester" }}">
     <div class="nav-wrapper">
       <a href="#!" class="brand-logo center" id="urnik-logo"> <!-- top centred logo: absolute -->
-        <i class="large material-icons hide-on-med-and-down">{% if ogled_starega_semestra %}history{% else %}schedule{% endif %}</i>
+        <i class="large material-icons hide-on-med-and-down">{{ ogled_starega_semestra|yesno:"history,schedule" }}</i>
         {{ naslov|default:izbrani_semester.ime }}
         {% if ogled_starega_semestra and naslov %}
         <small>
@@ -119,6 +119,12 @@
   <li><a href="{% url 'bugreport' %}"><i class="material-icons left">bug_report</i>Prijava napake</a></li>
   <li><a href="{% url 'help' %}"><i class="material-icons left">help</i>Navodila in pomoč</a></li>
 </ul> <!-- side nav -->
+{% if ogled_starega_semestra %}
+  <div id="old-semester-note" class="card">
+    Gledate pretekel semester. <a href="{% url 'zacetna_stran' %}">Nazaj na aktualen semester.</a>
+    <i class="material-icons close-icon" onclick="$(this.parentNode).fadeOut(200);">close</i>
+  </div>
+{% endif %}
 
 {% block content %}{% endblock content %}
 

--- a/urnik/templates/osnova.html
+++ b/urnik/templates/osnova.html
@@ -95,10 +95,10 @@
   </nav>
 </div> <!-- navbar fixed -->
 <ul class="sidenav" id="side-menu"> <!-- side navigation -->
-  <li><a href="{% url 'zacetna_stran' %}"><i class="material-icons left">home</i>Domov</a></li>
-  <li><a href="{% url 'kombiniran_pogled_form' %}"><i class="material-icons left">schedule</i>Kombiniran pogled</a></li>
+  <li><a href="{% url 'zacetna_stran' semester_id=izbrani_semester_id %}"><i class="material-icons left">home</i>Domov</a></li>
+  <li><a href="{% url 'kombiniran_pogled_form' semester_id=izbrani_semester_id %}"><i class="material-icons left">schedule</i>Kombiniran pogled</a></li>
   <li><a href="{% url 'rezervacije' %}"><i class="material-icons left">border_color</i>Rezervacije učilnic</a></li>
-  <li><a href="{% url 'proste' %}"><i class="material-icons left">event_available</i>Proste učilnice</a></li>
+  <li><a href="{% url 'proste' semester_id=izbrani_semester_id %}"><i class="material-icons left">event_available</i>Proste učilnice</a></li>
   {% if user.is_authenticated %}
     <li><a href="{% url 'nova_rezervacija' %}"><i class="material-icons left">assignment</i>Nova rezervacija</a></li>
   {% endif %}
@@ -107,7 +107,7 @@
   {% endif %}
   <li><a href="javascript:window.print();"><i class="material-icons left">print</i>Natisni stran</a></li>
   {% if user.is_staff %}
-    <li><a href="{% url 'printall' %}"><span class="tripple-icon side-icon">
+    <li><a href="{% url 'printall' semester_id=izbrani_semester_id %}"><span class="tripple-icon side-icon">
       <i class="material-icons">print</i>
       <i class="material-icons">print</i>
       <i class="material-icons">print</i>
@@ -125,28 +125,28 @@
 <script>
     M.AutoInit();
     var search_urls = {
-        "Meni: Urnik": "{% url 'zacetna_stran' %}",
-        "Meni: Kombiniran pogled": "{% url 'kombiniran_pogled_form' %}",
+        "Meni: Urnik": "{% url 'zacetna_stran' semester_id=izbrani_semester_id %}",
+        "Meni: Kombiniran pogled": "{% url 'kombiniran_pogled_form' semester_id=izbrani_semester_id %}",
         "Meni: Rezervacije učilnic": "{% url 'rezervacije' %}",
     {% if user.is_authenticated %}
         "Meni: Nova rezervacija": "{% url 'nova_rezervacija' %}",
     {% endif %}
     {% if user.is_staff %}
         "Meni: Preglej nove rezervacije": "{% url 'preglej_rezervacije' %}",
-        "Meni: Natisni vse": "{% url 'printall' %}",
+        "Meni: Natisni vse": "{% url 'printall' semester_id=izbrani_semester_id %}",
     {% endif %}
-        "Meni: Proste učilnice": "{% url 'proste' %}",
+        "Meni: Proste učilnice": "{% url 'proste' semester_id=izbrani_semester_id %}",
         "Meni: Natisni stran": "javascript:window.print();",
         "Meni: Ogled starejših urnikov": "{% url 'izbira_semestra' %}",
         "Meni: Prijava napake": "{% url 'bugreport' %}",
         "Meni: Navodila in pomoč": "{% url 'help' %}",
 
         {% for letnik in letniki_search %}
-            "{{ letnik }} ({{letnik.kratica}})": "{% url 'urnik_letnika' letnik.id %}",{% endfor %}
+            "{{ letnik }} ({{letnik.kratica}})": "{% url 'urnik_letnika' letnik_id=letnik.id semester_id=izbrani_semester_id %}",{% endfor %}
         {% for oseba in osebe_search %}
-            "{{ oseba.ime }} {{ oseba.priimek }}": "{% url 'urnik_osebe' oseba.id %}",{%  endfor %}
+            "{{ oseba.ime }} {{ oseba.priimek }}": "{% url 'urnik_osebe' oseba_id=oseba.id semester_id=izbrani_semester_id %}",{%  endfor %}
         {% for ucilnica in ucilnice_search %}
-            "Učilnica {{ ucilnica.oznaka }}": "{% url 'urnik_ucilnice' ucilnica.id %}",{% endfor %}
+            "Učilnica {{ ucilnica.oznaka }}": "{% url 'urnik_ucilnice' ucilnica_id=ucilnica.id semester_id=izbrani_semester_id %}",{% endfor %}
     };
 
     $(document).ready(function () {

--- a/urnik/templates/osnova.html
+++ b/urnik/templates/osnova.html
@@ -121,7 +121,7 @@
 </ul> <!-- side nav -->
 {% if ogled_starega_semestra %}
   <div id="old-semester-note" class="card">
-    Gledate pretekel semester. <a href="{% url 'zacetna_stran' %}">Nazaj na aktualen semester.</a>
+    Gledate pretekel semester. <a href="{% url 'zacetna_stran' %}">Nazaj na trenutni semester.</a>
     <i class="material-icons close-icon" onclick="$(this.parentNode).fadeOut(200);">close</i>
   </div>
 {% endif %}

--- a/urnik/templates/print_all.html
+++ b/urnik/templates/print_all.html
@@ -20,7 +20,7 @@
         <tr>
           <td>{{ moznost.1 }}</td>
           {% for oddelek in oddelki %}
-            <td><a href="{% url moznost.0 oddelek.0 %}" target="_blank">
+            <td><a href="{% url moznost.0 oddelek=oddelek.0 semester_id=izbrani_semester_id %}" target="_blank">
               <span class="tripple-icon left">
                 <i class="material-icons">print</i>
                 <i class="material-icons">print</i>

--- a/urnik/templates/proste_ucilnice.html
+++ b/urnik/templates/proste_ucilnice.html
@@ -50,7 +50,7 @@
   </div>
 
   <div class="card">
-    <form action="{% url 'proste_filter' %}" method="post">{% csrf_token %}
+    <form action="{% url 'proste_filter' semester_id=izbrani_semester_id %}" method="post">{% csrf_token %}
       <input type="hidden" name="qstring" value="{{ request.GET.urlencode }}">
       <div class="card-content">
         <span class="card-title">Omejite učilnice</span>

--- a/urnik/templates/zacetna_stran.html
+++ b/urnik/templates/zacetna_stran.html
@@ -13,9 +13,9 @@
       <tr>
         <td>
           <ul>
-            <li><a href="{% url 'kombiniran_pogled_form' %}"><i class="material-icons left">schedule</i>Kombiniran pogled</a></li>
+            <li><a href="{% url 'kombiniran_pogled_form' semester_id=izbrani_semester_id %}"><i class="material-icons left">schedule</i>Kombiniran pogled</a></li>
             <li><a href="{% url 'rezervacije' %}"><i class="material-icons left">border_color</i>Rezervacije učilnic</a></li>
-            <li><a href="{% url 'proste' %}"><i class="material-icons left">event_available</i>Proste učilnice</a></li>
+            <li><a href="{% url 'proste' semester_id=izbrani_semester_id %}"><i class="material-icons left">event_available</i>Proste učilnice</a></li>
             {% if user.is_authenticated %}
               <li><a href="{% url 'nova_rezervacija' %}"><i class="material-icons left">assignment</i>Nova rezervacija</a></li>
             {% endif %}
@@ -43,7 +43,7 @@
           {% for letnik in smer_l.list %}
             <tr>
               <td class="padded">
-                  <a href="{% url 'urnik_letnika' letnik.id %}">{{ letnik.leto }}</a>
+                  <a href="{% url 'urnik_letnika' letnik_id=letnik.id semester_id=izbrani_semester_id %}">{{ letnik.leto }}</a>
               </td>
             </tr>
           {% endfor %}
@@ -63,7 +63,7 @@
       {% for ucilnica in ucilnice %}
         <tr>
           <td class="padded">
-            <a href="{% url 'urnik_ucilnice' ucilnica.id %}">{{ ucilnica.oznaka }}</a>
+            <a href="{% url 'urnik_ucilnice' ucilnica_id=ucilnica.id semester_id=izbrani_semester_id %}">{{ ucilnica.oznaka }}</a>
             <small>
               {% if ucilnica.tip == ucilnica.RACUNALNISKA %}
                 <i class="tiny material-icons">computer</i>

--- a/urnik/templates/zacetna_stran.html
+++ b/urnik/templates/zacetna_stran.html
@@ -14,10 +14,12 @@
         <td>
           <ul>
             <li><a href="{% url 'kombiniran_pogled_form' semester_id=izbrani_semester_id %}"><i class="material-icons left">schedule</i>Kombiniran pogled</a></li>
+            {% if not ogled_starega_semestra %}
             <li><a href="{% url 'rezervacije' %}"><i class="material-icons left">border_color</i>Rezervacije učilnic</a></li>
             <li><a href="{% url 'proste' semester_id=izbrani_semester_id %}"><i class="material-icons left">event_available</i>Proste učilnice</a></li>
             {% if user.is_authenticated %}
               <li><a href="{% url 'nova_rezervacija' %}"><i class="material-icons left">assignment</i>Nova rezervacija</a></li>
+            {% endif %}
             {% endif %}
             <li><a href="{% url 'izbira_semestra' %}"><i class="material-icons left">history</i>Ogled starejših urnikov</a></li>
             <li><a href="{% url 'bugreport' %}"><i class="material-icons left">bug_report</i>Prijava napake</a></li>

--- a/urnik/urls.py
+++ b/urnik/urls.py
@@ -1,0 +1,45 @@
+"""urnik URL Configuration
+
+The `urlpatterns` list routes URLs to views. For more information please see:
+    https://docs.djangoproject.com/en/1.10/topics/http/urls/
+Examples:
+Function views
+    1. Add an import:  from my_app import views
+    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+Class-based views
+    1. Add an import:  from other_app.views import Home
+    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+Including another URLconf
+    1. Import the include() function: from django.conf.urls import url, include
+    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+"""
+from django.conf import settings
+from django.contrib import admin
+from django.contrib.auth import views as auth_views
+from django.urls import path, re_path, include
+
+import urnik.views
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('login/', auth_views.LoginView.as_view(template_name='login.html'), name='login'),
+    path('logout/', auth_views.LogoutView.as_view(), name='logout'),
+    path('rezervacije/', urnik.views.rezervacije, name='rezervacije'),
+    path('nova-rezervacija/', urnik.views.nova_rezervacija, name='nova_rezervacija'),
+    re_path(r'^nova-rezervacija/(?P<ucilnica_id>\d+)/(?P<ura>\d+)/(?P<teden>[0-9-]*)/(?P<dan_v_tednu>[0-6])/$',
+            urnik.views.nova_rezervacija, name='nova_rezervacija_za_ucilnico'),
+    path('preglej-rezervacije/', urnik.views.preglej_rezervacije, name='preglej_rezervacije'),
+    path('potrdi-rezervacijo/', urnik.views.potrdi_rezervacijo, name='potrdi_rezervacijo'),
+    path('potrdi-vse-rezervacije/', urnik.views.potrdi_vse_rezervacije, name='potrdi_vse_rezervacije'),
+    path('izbrisi-rezervacijo/', urnik.views.izbrisi_rezervacijo, name='izbrisi_rezervacijo'),
+    path('srecanje/<int:srecanje_id>/premakni/', urnik.views.premakni_srecanje, name='premakni_srecanje'),
+    path('srecanje/<int:srecanje_id>/podvoji/', urnik.views.podvoji_srecanje, name='podvoji_srecanje'),
+    path('srecanje/<int:srecanje_id>/odlozi/', urnik.views.odlozi_srecanje, name='odlozi_srecanje'),
+    path('srecanje/<int:srecanje_id>/trajanje/', urnik.views.nastavi_trajanje_srecanja, name='nastavi_trajanje_srecanja'),
+    path('preklopi_urejanje/', urnik.views.preklopi_urejanje, name='preklopi_urejanje'),
+    path('izberi-semester/', urnik.views.izbira_semestra, name='izbira_semestra'),
+    path('bugreport/', urnik.views.bug_report, name='bugreport'),
+    path('help/', urnik.views.help_page, name='help'),
+    path('', include('urnik.semester_urls'), kwargs={'semester_id': None}),
+    path('semester/<int:semester_id>/', include('urnik.semester_urls'))
+]

--- a/urnik/views.py
+++ b/urnik/views.py
@@ -27,7 +27,8 @@ def izbrani_semester(request):
 def ogled_starega_semestra(request):
     urejanje = request.session.get('urejanje', False)
     semester_id = izbrani_semester_id(request)
-    return not urejanje and semester_id is not None
+    return not urejanje and semester_id is not None and \
+        Semester.objects.filter(objavljen=True).latest('od').pk != semester_id
 
 def zacetna_stran(request, semester_id=None):
     ucilnice = Ucilnica.objects.objavljene()

--- a/urnik/views.py
+++ b/urnik/views.py
@@ -10,11 +10,13 @@ from urnik.iskanik_konfliktov import ProsteUcilnice, IskalnikKonfliktov
 from urnik.utils import teden_dneva
 from .models import *
 
+def izbrani_semester_id(request):
+    return request.resolver_match.kwargs.get('semester_id', None)
 
 def izbrani_semester(request):
     if request.session.get('urejanje', False):
         return Semester.objects.latest('od')
-    semester_id = request.session.get('semester_id')
+    semester_id = izbrani_semester_id(request)
     if semester_id:
         try:
             return Semester.objects.get(pk=semester_id)
@@ -24,19 +26,10 @@ def izbrani_semester(request):
 
 def ogled_starega_semestra(request):
     urejanje = request.session.get('urejanje', False)
-    semester_id = request.session.get('semester_id')
+    semester_id = izbrani_semester_id(request)
     return not urejanje and semester_id is not None
 
-def izberi_semester(request, semester_id=None):
-    if semester_id:
-        semester_id = get_object_or_404(Semester, id=semester_id)
-        request.session['semester_id'] = semester_id.id
-    else:
-        if 'semester_id' in request.session:
-            del request.session['semester_id']
-    return redirect(reverse('zacetna_stran'))
-
-def zacetna_stran(request):
+def zacetna_stran(request, semester_id=None):
     ucilnice = Ucilnica.objects.objavljene()
     return render(request, 'zacetna_stran.html', {
         'stolpci_smeri': [
@@ -54,7 +47,7 @@ def izbira_semestra(request):
     })
 
 
-def kombiniran_pogled_form(request):
+def kombiniran_pogled_form(request, semester_id=None):
     osebe = sorted(Oseba.objects.aktivni(), key=lambda oseba: oseba.vrstni_red())
     columns = 3
     length = len(osebe)
@@ -212,31 +205,31 @@ def urnik(request, srecanja, naslov, barve=None):
         })
 
 
-def urnik_osebe(request, oseba_id):
+def urnik_osebe(request, oseba_id, semester_id=None):
     oseba = get_object_or_404(Oseba, id=oseba_id)
     naslov = str(oseba)
     return urnik(request, oseba.vsa_srecanja(izbrani_semester(request)), naslov)
 
 
-def urnik_letnika(request, letnik_id):
+def urnik_letnika(request, letnik_id, semester_id=None):
     letnik = get_object_or_404(Letnik, id=letnik_id)
     naslov = str(letnik)
     return urnik(request, letnik.srecanja(izbrani_semester(request)).all(), naslov)
 
 
-def urnik_ucilnice(request, ucilnica_id):
+def urnik_ucilnice(request, ucilnica_id, semester_id=None):
     ucilnica = get_object_or_404(Ucilnica, id=ucilnica_id)
     naslov = 'Učilnica {}'.format(ucilnica.oznaka)
     return urnik(request, ucilnica.srecanja.filter(semester=izbrani_semester(request)), naslov, barve=[])
 
 
-def urnik_predmeta(request, predmet_id):
+def urnik_predmeta(request, predmet_id, semester_id=None):
     predmet = get_object_or_404(Predmet, id=predmet_id)
     naslov = str(predmet)
     return urnik(request, predmet.srecanja.filter(semester=izbrani_semester(request)), naslov)
 
 
-def kombiniran_pogled(request):
+def kombiniran_pogled(request, semester_id=None):
     letniki = Letnik.objects.filter(id__in=request.GET.getlist('letnik'))
     osebe = Oseba.objects.filter(id__in=request.GET.getlist('oseba'))
     ucilnice = Ucilnica.objects.filter(id__in=request.GET.getlist('ucilnica'))
@@ -249,7 +242,7 @@ def kombiniran_pogled(request):
     return urnik(request, srecanja, 'Kombiniran pogled', barve=list(letniki) + list(osebe) + list(ucilnice))
 
 
-def proste_ucilnice(request):
+def proste_ucilnice(request, semester_id=None):
     teden = request.GET.get('teden', None)
     try:
         teden = parse_date(teden)
@@ -315,13 +308,13 @@ def proste_ucilnice(request):
 
 
 @require_POST
-def proste_ucilnice_filter(request):
+def proste_ucilnice_filter(request, semester_id=None):
     tipi = [k for k in Ucilnica.OBJAVLJENI_TIPI if request.POST.get(k, '') == 'on']
     velikosti = [k for k, v in UcilnicaQuerySet.VELIKOST if request.POST.get(k, '') == 'on']
     q = QueryDict(request.POST.get('qstring', ''), mutable=True)
     q.setlist('tip', tipi)
     q.setlist('velikost', velikosti)
-    response = redirect('proste')
+    response = redirect(reverse('proste', kwargs={'semester_id': semester_id}))
     response['Location'] += "?" + q.urlencode()
     return response
 
@@ -389,7 +382,7 @@ def help_page(request):
     })
 
 
-def print_all(request):
+def print_all(request, semester_id=None):
     return render(request, 'print_all.html', {
         'naslov': 'Množično tiskanje',
         'oddelki': Letnik.ODDELEK,
@@ -397,13 +390,13 @@ def print_all(request):
     })
 
 
-def print_all_ucilnice(request, oddelek):
+def print_all_ucilnice(request, oddelek, semester_id=None):
     return render(request, 'print_all_list.html', {
-        'links': [reverse('urnik_ucilnice', args=[u.id]) for u in Ucilnica.objects.filter(tip=oddelek)]
+        'links': [reverse('urnik_ucilnice', kwargs={'ucilnica_id': u.id, 'semester_id': semester_id}) for u in Ucilnica.objects.filter(tip=oddelek)]
     })
 
 
-def print_all_smeri(request, oddelek):
+def print_all_smeri(request, oddelek, semester_id=None):
     return render(request, 'print_all_list.html', {
-        'links': [reverse('urnik_letnika', args=[l.id]) for l in Letnik.objects.filter(oddelek=oddelek)]
+        'links': [reverse('urnik_letnika', kwargs={'letnik_id': l.id, 'semester_id': semester_id}) for l in Letnik.objects.filter(oddelek=oddelek)]
     })


### PR DESCRIPTION
Kot je bilo omenjeno v #70 in #72, bi bilo bolje, da je izbira semestra eksplicitna v URL-ju. Ta PR doda možnost dodajanja `semester/<int:semester_id>/` pred relevantne URL-je - če te predpone ni, potem se URL nanaša na trenutni semester (`semester_id == None`).

Ne zagotavljam, da sem ujel čisto vsako povezavo, da bo pravilno kazala na izbrani semester - urejanja urnika in rezervacij se nisem dotikal. Poleg tega nisem čisto prepričan, če je smiselno, da imamo *Proste učilnice* za prejšnje semestre - konkretno v tem primeru trenutno ni možno izbirati tedna za prikaz, saj se prikažejo samo prihajajoči tedni.

Po mojem lahko v tem pull requestu uredimo še ostale pripombe iz #70.

Closes #70.