### PR TITLE
Pospešil pridobivanje rezervacij.

### DIFF
--- a/urnik/iskanik_konfliktov.py
+++ b/urnik/iskanik_konfliktov.py
@@ -108,13 +108,15 @@ class IskalnikKonfliktov(object):
                 self.zasedenost_ucilnic[s.ucilnica_id, d].append(s)
 
     def dodaj_rezervacije(self, rezervacije):
+        """Queryset rezervacije mora biti prefetchan tako, da obstaja atribut seznam_ucilnic"""
         for r in rezervacije:
-            for u in r.ucilnice.all():
+            for u in r.seznam_ucilnic:
                 for d in r.dnevi_med(self.min_datum, self.max_datum):
                     self.rezerviranost_ucilnic[u.pk, d].append(r)
 
     @staticmethod
     def za_rezervacije(rezervacije: RezervacijaQuerySet):
+        """Queryset rezervacije mora biti prefetchan tako, da obstaja atribut seznam_ucilnic"""
         min_datum = datetime.date.max
         max_datum = datetime.date.min
         ucilnice = set()
@@ -123,7 +125,7 @@ class IskalnikKonfliktov(object):
                 min_datum = r.zacetek
             if r.konec > max_datum:
                 max_datum = r.konec
-            ucilnice.update(r.ucilnice.all())
+            ucilnice.update(r.seznam_ucilnic)
 
         iskalnik = IskalnikKonfliktov(ucilnice, min_datum, max_datum)
         iskalnik.dodaj_srecanja()
@@ -131,7 +133,7 @@ class IskalnikKonfliktov(object):
         return iskalnik
 
     def konflikti_z_rezervacijo(self, r: Rezervacija):
-        for u in r.ucilnice.all():
+        for u in r.seznam_ucilnic:
             for d in r.dnevi():
                 k = self.konflikti(u, d, r.od, r.do, r)
                 if k:
@@ -141,7 +143,7 @@ class IskalnikKonfliktov(object):
         """Vrne konflikte z dejavnostjo, ki bi v ucilnici `ucilnica` potekala dne `datum` od ure `od` do `do`."""
         konflikti = Konflikt()
         if ucilnica not in self.ucilnice:
-            raise ValueError("Struktura iskanja ni bila pripravljena za iskanje konfliktov v učinici {}".format(ucilnica))
+            raise ValueError("Struktura iskanja ni bila pripravljena za iskanje konfliktov v učilnici {}".format(ucilnica))
         if not (self.min_datum <= datum <= self.max_datum):
             raise ValueError("Struktura iskanja ni bila pripravljena za iskanje konfliktov dne {}".format(datum))
 

--- a/urnik/templates/preglej_rezervacije.html
+++ b/urnik/templates/preglej_rezervacije.html
@@ -80,12 +80,12 @@
               </td>
               <td>{{ r.od }}&ndash;{{ r.do }}</td>
               <td>
-                {% for o in r.osebe.all %}
+                {% for o in r.seznam_oseb %}
                   <a href="{% url 'urnik_osebe' o.pk %}">{{ o }}</a>{% if not forloop.last %},{% endif %}
                 {% endfor %}
               </td>
               <td>
-                {% for u in r.ucilnice.all %}
+                {% for u in r.seznam_ucilnic %}
                   <a href="{% url 'urnik_ucilnice' u.pk %}">{{ u }}</a>{% if not forloop.last %},{% endif %}
                 {% endfor %}
               </td>
@@ -93,8 +93,8 @@
                 {{ k }}
               </td>
               <td>
-                {% if r.predmeti.all %}
-                  ({% for p in r.predmeti.all %}<a href="{% url 'urnik_predmeta' p.id %}">{{ p.opisno_ime }}</a>{% if forloop.last %}){% else %}, {% endif %}{% endfor %}
+                {% if r.seznam_predmetov %}
+                  ({% for p in r.seznam_predmetov %}<a href="{% url 'urnik_predmeta' p.id %}">{{ p.opisno_ime }}</a>{% if forloop.last %}){% else %}, {% endif %}{% endfor %}
                 {% else %}
                   /
                 {% endif %}
@@ -104,7 +104,7 @@
               <td>
                 <form action="{% url 'izbrisi_rezervacijo' %}" method="post"
                       onsubmit="return window.confirm('Ste prepričani, da želite izbrisati to ' +
-                          'rezervacijo?\nV primeru izbrisa bi bilo dobro obvestiti osebe: {{ r.osebe.all|join:", " }}.');">
+                          'rezervacijo?\nV primeru izbrisa bi bilo dobro obvestiti osebe: {{ r.seznam_oseb|join:", " }}.');">
                   {% csrf_token %}
                   <input type="hidden" name="r-pk" value="{{ r.pk }}">
                   <input type="hidden" value="{% url_with_get %}" name="redirect">
@@ -123,12 +123,12 @@
                           {% for rez in konflikti.rezervacije %}
                             <li>
                               Rezervacija
-                              {% if not rez.osebe %}
+                              {% if not rez.seznam_oseb %}
                                 neznane osebe
-                              {% elif rez.osebe.all|length_is:1 %}
-                                osebe {{ rez.osebe.all.0 }}
+                              {% elif rez.seznam_oseb|length_is:1 %}
+                                osebe {{ rez.seznam_oseb.0 }}
                               {% else %}
-                                oseb {{ rez.osebe.all|join:", " }}
+                                oseb {{ rez.seznam_oseb|join:", " }}
                               {% endif %}
                               od {{ rez.od }} do {{ rez.do }}
                               z razlogom &raquo;{{ rez.opomba }}&laquo;.

--- a/urnik/templates/rezervacije.html
+++ b/urnik/templates/rezervacije.html
@@ -36,12 +36,12 @@
                 <a href="{% url 'urnik_ucilnice' rezervacija.ucilnica.pk %}">{{ rezervacija.ucilnica }}</a>,
                 {{ rezervacija.od }}–{{ rezervacija.do }},
                 <small>
-                  {% for oseba in rezervacija.osebe.all %}
+                  {% for oseba in rezervacija.osebe %}
                     <a href="{% url 'urnik_osebe' oseba.pk %}">{{ oseba }}</a>,
                   {% endfor %}
                   {{ rezervacija.opomba }}
-                  {% if rezervacija.predmeti.all %}
-                    ({% for predmet in rezervacija.predmeti.all %}<a href="{% url 'urnik_predmeta' p.id %}">{{ p.opisno_ime }}</a>{% if forloop.last %}){% else %}, {% endif %}{% endfor %}
+                  {% if rezervacija.predmeti %}
+                    ({% for p in rezervacija.predmeti %}<a href="{% url 'urnik_predmeta' p.id %}">{{ p.opisno_ime }}</a>{% if forloop.last %}){% else %}, {% endif %}{% endfor %}
                   {% endif %}
                 </small>
                 {% if user.is_staff and not rezervacija.potrjena and rezervacija.konflikti %}
@@ -54,13 +54,13 @@
                   {% for rez in rezervacija.konflikti.rezervacije %}
                     <li><b>Konflikt:</b>
                       Učilnico {{ rezervacija.ucilnica }} je od {{ rez.od }} do {{ rez.do }}
-                      rezervirala oseba {{ rez.osebe.all.0|default:"neznan" }}
+                      rezervirala oseba {{ rez.osebe.0|default:"neznan" }}
                       z razlogom &raquo;{{ rez.opomba }}&laquo;.
                     </li>
                   {% endfor %}
                   {% for s in rezervacija.konflikti.srecanja %}
                     <li>
-                      V učilnici {{ s.ucilnica }} od {{ s.od }} do {{ s.do }} poteka predmet {{ s.predmet }}.
+                      V učilnici {{ rezervacija.ucilnica }} od {{ s.od }} do {{ s.do }} poteka predmet {{ s.predmet }}.
                     </li>
                   {% endfor %}
                 </ul></li>


### PR DESCRIPTION
Pri meni lokalno je nalaganje strani trajalo 1.3s. Veliko časa se je porabilo v `_fetch` zaradi djangotovega prefetcha (kar ne šteje v query time baze), in https://stackoverflow.com/questions/42838010/django-prefetch-related-optimize-query-but-still-very-slow da namig, da se zadeva precej spospeši, če namesto v queryset managerju rezultate shranimo kar v seznamu z `Prefetch` in `to_attr` metodo. Pri letnikih je sicer potreben gnezned prefetch, pa možno da sem kakšnega pozabil, ker v bazi ni predmetov.

Zdaj je pri meni čas okoli 0.35s, od česar se večina (0.34s) časa porabi v `defaulttags.py:155(render)`, kar se mi zdi da je rendranje `{% url %}` tagov.