### PR TITLE
Fixed double importing and an incorrect weekday range

### DIFF
--- a/project/settings/production.py
+++ b/project/settings/production.py
@@ -27,10 +27,6 @@ DATABASES = {
     },
 }
 
-
-import ldap
-from django_auth_ldap.config import LDAPSearch
-
 AUTHENTICATION_BACKENDS += (
     'django_auth_ldap.backend.LDAPBackend',
 )

--- a/urnik/models.py
+++ b/urnik/models.py
@@ -281,7 +281,7 @@ class SrecanjeQuerySet(models.QuerySet):
     def v_tednu_semestra(self, teden, semester):
         if teden is None:
             return self
-        veljavni_dnevi = [dan for dan in range(0, 5) if semester.od <= teden + datetime.timedelta(days=dan) <= semester.do]
+        veljavni_dnevi = [dan for dan in range(1, 6) if semester.od <= teden + datetime.timedelta(days=dan) <= semester.do]
         return self.filter(dan__in=veljavni_dnevi)
 
     def za_urnik(self):


### PR DESCRIPTION
V project/settings/production.py je izbrisan dvojni importing 
```python
import ldap
from django_auth_ldap.config import LDAPSearch
```
ki se zgodi v 1. in 2. vrstici in v 31.,32. vrstici.


Prav tako je odpravljen bug, ki ne prikazuje petkov v specifičnem tednu. 

```python
veljavni_dnevi = [dan for dan in range(0, 5) if semester.od <= teden + datetime.timedelta(days=dan) <= semester.do]
```
Dnevi so v modelih šteti od 1->ponedeljek ... 5->petek , tako da je treba v range zanki iterirati do 6.
