### PR TITLE
Bolj pametno iskanje trenutnega semestra

### DIFF
--- a/urnik/models.py
+++ b/urnik/models.py
@@ -4,6 +4,8 @@ from copy import deepcopy
 
 from django.conf import settings
 from django.db import models
+from django.utils.timezone import now
+
 from urnik.utils import teden_dneva
 
 MIN_URA, MAX_URA = 7, 20
@@ -195,6 +197,9 @@ class SemesterQuerySet(models.QuerySet):
     def v_obdobju(self, od, do):
         return self.filter(do__gte=od, od__lte=do)
 
+    def vsebuje_dan(self, dan):
+        return self.filter(od__lte=dan, do__gte=dan)
+
 
 class Semester(models.Model):
     ime = models.CharField(max_length=192)
@@ -238,6 +243,42 @@ class Semester(models.Model):
         if self.do >= prvi_dan:
             tedni.add(teden_dneva(self.do))
         return tedni
+
+    @classmethod
+    def najblizji_semester(cls, danes=None, samo_objavljeni=True):
+        if danes is None:
+            danes = now()
+        semestri = Semester.objects.all()
+        if samo_objavljeni:
+            semestri = semestri.filter(objavljen=True)
+
+        # Ali smo v veljavnem semestru
+        try:
+            return semestri.vsebuje_dan(danes).latest('od')
+        except Semester.DoesNotExist:
+            pass
+
+        prej = semestri.filter(do__lt=danes)
+        potem = semestri.filter(od__gt=danes)
+        try:
+            prejsnji = prej.latest('do')
+            razlika_prejsnji = (danes.date() - prejsnji.do).total_seconds()
+        except Semester.DoesNotExist:
+            prejsnji = None
+            razlika_prejsnji = float('inf')
+        try:
+            kasnejsi = potem.earliest('od')
+            razlika_kasnejsi = (kasnejsi.od - danes.date()).total_seconds()
+        except Semester.DoesNotExist:
+            kasnejsi = None
+            razlika_kasnejsi = float('inf')
+
+        if razlika_prejsnji < razlika_kasnejsi:
+            # Je zagotovo Semester, ker float('inf') < float('inf') ~> False
+            return prejsnji
+        if kasnejsi:
+            return kasnejsi
+        return semestri.latest('od')
 
 
 class SrecanjeQuerySet(models.QuerySet):

--- a/urnik/tests/test_najblizji_semester.py
+++ b/urnik/tests/test_najblizji_semester.py
@@ -1,0 +1,58 @@
+from django.test import TestCase
+from urnik.models import Semester
+from datetime import datetime
+
+
+class TestNajblizjiSemester(TestCase):
+
+    def test_prazno(self):
+        datum = datetime(2020, 1, 1)
+        self.assertRaises(Semester.DoesNotExist, Semester.najblizji_semester,
+                          datum)
+
+    def test_najblizji(self):
+        sem1 = Semester.objects.create(
+            od="2020-01-01", do="2020-10-01", ime="Semester 1", objavljen=True
+        )
+        blizu = Semester.najblizji_semester(datetime(2020, 9, 1))
+        self.assertEqual(sem1, blizu)
+        blizu = Semester.najblizji_semester(datetime(2020, 10, 2))
+        self.assertEqual(sem1, blizu)
+        blizu = Semester.najblizji_semester(datetime(2019, 10, 2))
+        self.assertEqual(sem1, blizu)
+        blizu = Semester.najblizji_semester(datetime(2020, 11, 2))
+        self.assertEqual(sem1, blizu)
+
+        sem2 = Semester.objects.create(
+            od="2020-10-05", do="2020-10-25", ime="Semester 2"
+        )
+
+        blizu = Semester.najblizji_semester(datetime(2020, 9, 1))
+        self.assertEqual(sem1, blizu)
+        blizu = Semester.najblizji_semester(datetime(2020, 10, 2))
+        self.assertEqual(sem1, blizu)
+        blizu = Semester.najblizji_semester(datetime(2019, 10, 2))
+        self.assertEqual(sem1, blizu)
+
+        blizu = Semester.najblizji_semester(datetime(2020, 10, 4))
+        self.assertEqual(sem1, blizu)
+        blizu = Semester.najblizji_semester(datetime(2020, 11, 2))
+        self.assertEqual(sem1, blizu)
+        blizu = Semester.najblizji_semester(datetime(2021, 11, 2))
+        self.assertEqual(sem1, blizu)
+
+        sem2.objavljen = True
+        sem2.save()
+
+        blizu = Semester.najblizji_semester(datetime(2020, 9, 1))
+        self.assertEqual(sem1, blizu)
+        blizu = Semester.najblizji_semester(datetime(2020, 10, 2))
+        self.assertEqual(sem1, blizu)
+        blizu = Semester.najblizji_semester(datetime(2019, 10, 2))
+        self.assertEqual(sem1, blizu)
+        blizu = Semester.najblizji_semester(datetime(2020, 10, 4))
+        self.assertEqual(sem2, blizu)
+        blizu = Semester.najblizji_semester(datetime(2020, 11, 2))
+        self.assertEqual(sem2, blizu)
+        blizu = Semester.najblizji_semester(datetime(2021, 11, 2))
+        self.assertEqual(sem2, blizu)

--- a/urnik/views.py
+++ b/urnik/views.py
@@ -28,7 +28,7 @@ def izbrani_semester(request):
         except:
             pass
     try:
-        return Semester.objects.filter(objavljen=True).latest('od')
+        return Semester.najblizji_semester(now())
     except Semester.DoesNotExist:
         raise ValueError("Za uporabo aplikacije dodajte v bazo vsaj en objavljen semester.")
 


### PR DESCRIPTION
Trenutno iskanje aktivnega semestra vzame najkasnejši aktivni semester. Če urnik vsebuje javno objavljen urnik za celotno leto, potem je tudi recimo oktobra avtomatično izbran poletni semester. 

Po tem PR-ju se trenutni semester določi kot tisti, ki vsebuje današnji dan, ali pa najbližji objavljen semester (tisti ki se konča ali začne najbližje). Za vsak slučaj, če se semestri čudno prekrivajo, kot fallback vzame najkasnejši aktivni semester.

Za FMF to trenutno ni problematično, saj urniki niso objavljeni vnaprej, bi pa to lahko prišlo prav v prihodnosti.

Testi potrebujejo #101 