### PR TITLE
Hide overlay when printing to fix #99

### DIFF
--- a/urnik/static/print.css
+++ b/urnik/static/print.css
@@ -58,6 +58,6 @@ nav div.nav-wrapper ul.left, nav div.nav-wrapper ul.right, #side-menu, a.button-
 }
 
 /* ce je stranski meni odprt */
-#side-menu, #sidenav-overlay, div.drag-target {
-    display: none;
+#side-menu, .sidenav-overlay, div.drag-target {
+    display: none !IMPORTANT;
 }


### PR DESCRIPTION
Ta PR popravi težave pri tiskanju, kadar je odprt hamburger menu. Ker je `class="sidenav-overlay"` in ne `id`, ga v css-ju dobimo kot `.sidenav-overlay` in ne `#`.

Poleg tega ima element svoj inline style, ki ima višjo prioriteto od tistega v datoteki print.css; dodatek `!IMPORTANT` privzdigne prioriteto na najvišjo. (Elegantnejša rešitev bi sicer bila, da element ne bi imel z javascriptom spreminjajočega se inline stylinga.)

Fixes #99 

